### PR TITLE
[WIP] Poor matrix standardization with zero-sd cols

### DIFF
--- a/src/quantcore/matrix/matrix_base.py
+++ b/src/quantcore/matrix/matrix_base.py
@@ -138,7 +138,7 @@ class MatrixBase(ABC):
 
 
 def one_over_var_inf_to_val(arr: np.ndarray, val: float) -> np.ndarray:
-    zeros = np.where(arr == 0)
+    zeros = np.where(np.abs(arr) < 1e-7)
     with np.errstate(divide="ignore"):
         one_over = 1 / arr
     one_over[zeros] = val

--- a/tests/test_matrices.py
+++ b/tests/test_matrices.py
@@ -495,12 +495,3 @@ def test_pandas_to_matrix():
     }
     for submat in mat.matrices:
         assert submat.shape[1] == nb_col_by_type[type(submat)]
-
-
-def test_transpose_square_dot_weights():
-    n_rows = 100
-    mat = mx.DenseMatrix(np.ones((n_rows, 1)))
-    weights = np.ones(n_rows) / n_rows
-    col_means = np.array([1.0])
-    sds = mat.get_col_stds(weights, col_means)
-    assert np.all(sds == 0)


### PR DESCRIPTION
Fixes #34 

When a column has a standard deviation of zero, standardizing it is numerically fraught. If we detect that the standard deviation is zero, we don't attempt to standardize it, but if we mis-measure the SD as a very small number, we attempt to standardize it by multiplying the column by one over the very small number. This led to overflow errors in #34, and we now have a test for it in this repo that you can see failing with the old behavior at https://github.com/Quantco/quantcore.matrix/pull/35/checks?check_run_id=933876250. It is fixed by treating columns with a measured standard deviation of close to zero as zero.

Once this is merged, we should make sure to bump the tag and update the dependency in quantcore.glm to the newest version