### PR TITLE
Optimizing column handling for split dot/transpose-dot.

### DIFF
--- a/src/quantcore/matrix/split_matrix.py
+++ b/src/quantcore/matrix/split_matrix.py
@@ -212,8 +212,6 @@ class SplitMatrix(MatrixBase):
         if v.shape[0] != self.shape[1]:
             raise ValueError(f"shapes {self.shape} and {v.shape} not aligned")
 
-        if cols is None:
-            cols = np.arange(self.shape[1], dtype=np.int32)
         _, subset_cols, n_cols = self._split_col_subsets(cols)
 
         out_shape = [self.shape[0]] + ([] if v.ndim == 1 else list(v.shape[1:]))
@@ -241,8 +239,6 @@ class SplitMatrix(MatrixBase):
         """
 
         vec = np.asarray(vec)
-        if cols is None:
-            cols = np.arange(self.shape[1], dtype=np.int32)
         subset_cols_indices, subset_cols, n_cols = self._split_col_subsets(cols)
 
         out_shape = [n_cols] + list(vec.shape[1:])


### PR DESCRIPTION
* Improved column handling a little bit to leave `cols = None` in SplitMatrix which just gets passed down to the child matrices and handled properly there. This is ~15% faster.
* Improved the benchmarks so that the runtimes are more robust. Now running 200 iterations instead of just 1. We take the minimum runtime over those 200 iterations.
* Taking snapshots in MemoryPoller to help diagnose where memory is being allocated. This will be useful for fixing #25.

Before optimization:
```
                 operation           storage memory        time
0            matrix-vector  quantcore.matrix      0  0.00392222
1  matrix-transpose-vector  quantcore.matrix      0   0.0030477
```

After optimization:
```
                 operation           storage memory        time
0            matrix-vector  quantcore.matrix      0  0.00356746
1  matrix-transpose-vector  quantcore.matrix      0  0.00268245
```