### PR TITLE
Multiplication of categorical matrix

### DIFF
--- a/src/quantcore/matrix/categorical_matrix.py
+++ b/src/quantcore/matrix/categorical_matrix.py
@@ -299,5 +299,19 @@ class CategoricalMatrix(MatrixBase):
 
         return res
 
+    def multiply(self, other) -> sps.csr_matrix:
+        """Element-wise multiplication of each column with other"""
+        if self.shape[0] != other.shape[0]:
+            raise ValueError(
+                f"Shape do not match. Expected a length of {self.shape[0]} but got {len(other)}."
+            )
+
+        return sps.csr_matrix(
+            (np.squeeze(other), self.indices, np.arange(self.shape[0] + 1, dtype=int)),
+            shape=self.shape,
+        )
+
+    __mul__ = multiply
+
     def __repr__(self):
         return str(self.cat)

--- a/tests/test_categorical_matrix.py
+++ b/tests/test_categorical_matrix.py
@@ -41,3 +41,13 @@ def test_transpose_matvec(cat_vec):
     res = cat_mat.transpose_matvec(other)
     expected = cat_mat.A.T.dot(other)
     np.testing.assert_allclose(res, expected)
+
+
+def test_multiply(cat_vec):
+    cat_mat = CategoricalMatrix(cat_vec)
+    other = np.arange(len(cat_vec))[:, None]
+    res = cat_mat * other
+    res2 = cat_mat.multiply(other)
+    expected = cat_mat.A * other
+    np.testing.assert_allclose(res.A, expected)
+    np.testing.assert_allclose(res2.A, expected)


### PR DESCRIPTION
Addition of an efficient matrix multiplication method to the `CategoricalMatrix` class.

The result is a csr_matrix, so it's not directly compatible with `SparseMatrix`.