### PR TITLE
Update changelog for 1.0.2 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,12 +7,13 @@
 Changelog
 =========
 
-Unreleased
-----------
+1.0.2 - 2020-04-20
+------------------
 
 **Other changes:**
 
 - Added Python 3.9 support.
+- Use ``scipy.sparse`` dot product when MKL isn't available.
 
 1.0.1 - 2020-11-25
 ------------------


### PR DESCRIPTION
I just saw that we don't have a 1.0.1 release for osx on our conda channel. Since it's easier to make a fresh release than to patch the conda channel (for me anyways), let's release 1.0.2.

Checklist
* [x] Added a `CHANGELOG.rst` entry
