### PR TITLE
Initial packaging setup for BLIS

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -33,6 +33,7 @@ requirements:
     - mako
     - numpy
     - pip
+    - quantcore.blis >=0.8.2
     - scikit-learn >=0.23
     - setuptools_scm
     - xsimd
@@ -42,6 +43,7 @@ requirements:
     - numexpr
     - {{ pin_compatible('numpy') }}
     - pandas
+    - quantcore.blis >=0.8.2
     - scikit-learn >=0.23
     - scipy
 

--- a/environment-win.yml
+++ b/environment-win.yml
@@ -20,6 +20,7 @@ dependencies:
   - pre-commit
   - pytest
   - pytest-xdist
+  - quantcore.blis >=0.8.2
   - seaborn-base
   - setuptools_scm
   - sphinx

--- a/environment.yml
+++ b/environment.yml
@@ -21,6 +21,7 @@ dependencies:
   - pre-commit
   - pytest
   - pytest-xdist
+  - quantcore.blis >=0.8.2
   - seaborn-base
   - setuptools_scm
   - sphinx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ['setuptools', 'setuptools-scm', 'wheel']
+requires = ['setuptools', 'setuptools-scm', 'wheel', 'mako', 'numpy', 'Cython']
 
 [tool.black]
 exclude = '''

--- a/src/quantcore/matrix/ext/dense.pyx
+++ b/src/quantcore/matrix/ext/dense.pyx
@@ -7,6 +7,17 @@ from cython cimport floating
 from cython.parallel import prange
 
 
+cdef extern from "<blis/blis.h>":
+    struct obj_s:
+        pass
+    ctypedef int num_t
+    ctypedef int dim_t
+    ctypedef int inc_t
+
+    void bli_obj_create_with_attached_buffer(num_t, dim_t, dim_t, void*, inc_t, inc_t, obj_s*)
+    void bls_gemm(obj_s*, obj_s*, obj_s*, obj_s*, obj_s*, obj_s*)
+    void* bli_obj_buffer(obj_s*)
+
 cdef extern from "dense_helpers.cpp":
     void _denseC_sandwich[F](int*, int*, F*, F*, F*, int, int, int, int, int, int, int) nogil
     void _denseF_sandwich[F](int*, int*, F*, F*, F*, int, int, int, int, int, int, int) nogil


### PR DESCRIPTION
Initial packaging setup for using BLIS in place of the dense sandwich product code.

Preliminary checklist:
- [ ] Complete Cythonization in `dense.pyx`. I have added the most important BLIS function signatures, but the actual usage isn't there yet.
- [x] Test that the build actually works. There is a chance that the `conda.recipe` will fail because BLIS gets installed to `$PREFIX`, which is not the same as `$CONDA_PREFIX`. Cython might not be able to find `blis.h`.