### PR TITLE
improved __repr__ method

### DIFF
--- a/src/quantcore/matrix/split_matrix.py
+++ b/src/quantcore/matrix/split_matrix.py
@@ -384,7 +384,10 @@ class SplitMatrix(MatrixBase):
     def __repr__(self):
         out = "SplitMatrix:"
         for i, mat in enumerate(self.matrices):
-            out += f"\n\nComponent {i} with type {mat.__class__.__name__}\n" + str(mat)
+            out += (
+                f"\n\nComponent {i} with type {mat.__class__.__name__}\n"
+                + mat.__repr__()
+            )
         return out
 
     __array_priority__ = 13


### PR DESCRIPTION
This is a tiny change, but for consistency it would be better to call the `__repr__` method of a splitmatrix's children instead of `__str__`. 

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a `CHANGELOG.rst` entry
