### PR TITLE
Fix wrong PyPI url

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -75,4 +75,3 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.GH_PYPI_UPLOAD }}
-          repository_url: https://pypi.org/legacy/


### PR DESCRIPTION
I've manually uploaded the wheels to PyPI for the 3.0.4 release. The changes in this PR have been tested on glum.
For reference, the correct upload url is: https://upload.pypi.org/legacy/, which is the default value of twine.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a `CHANGELOG.rst` entry
