### PR TITLE
Add pip requirements

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,13 @@
 Changelog
 =========
 
+3.0.5 - 2021-11-05
+------------------
+
+**Other changes**
+
+- We are now specifying the run time dependencies in ``setup.py``, so that missing dependencies are automatically installed from PyPI when installing ``tabmat`` via pip.
+
 3.0.4 - 2021-11-03
 ------------------
 

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,9 +1,8 @@
 {% set name = "tabmat" %}
-{% set version = "3.0.1" %}
 
 package:
   name: {{ name|lower }} 
-  version: {{ version }}
+  version: {{ environ.get('GIT_DESCRIBE_TAG', '').lstrip('v') }}{% if environ.get('GIT_DESCRIBE_NUMBER', 0)|int != 0 %}.post{{ GIT_DESCRIBE_NUMBER }}+{{ GIT_DESCRIBE_HASH }}{% endif %}
 
 source:
   git_url: ../
@@ -32,16 +31,12 @@ requirements:
     - mako
     - numpy
     - pip
-    - scikit-learn >=0.23
     - setuptools_scm
     - xsimd
   run:
     - python
-    - joblib
-    - numexpr
     - {{ pin_compatible('numpy') }}
     - pandas
-    - scikit-learn >=0.23
     - scipy
 
 test:

--- a/setup.py
+++ b/setup.py
@@ -136,7 +136,7 @@ setup(
     ],
     package_dir={"": "src"},
     packages=find_packages(where="src"),
-    install_requires=[],
+    install_requires=["numpy", "pandas", "scipy"],
     ext_modules=cythonize(ext_modules, annotate=False),
     zip_safe=False,
 )


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a `CHANGELOG.rst` entry

Currently, when we do `pip install tabmat`, we're not installing run time dependencies. I'm now adding them to setup.py.

Also, I cleaned up the conda recipe a bit. These changes also need to be ported to the feedstock repo (see https://github.com/conda-forge/tabmat-feedstock/pull/6).