### PR TITLE
Skip musllinux wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ skip_glob = '\.eggs/*,\.git/*,\.venv/*,build/*,dist/*'
 default_section = 'THIRDPARTY'
 
 [tool.cibuildwheel]
-skip = ["cp310-*", "pp*"]
+skip = ["cp310-*", "pp*", "*-musllinux_*"]
 test-requires = ["pytest", "pytest-xdist"]
 
 [tool.cibuildwheel.macos]


### PR DESCRIPTION
musllinux is not yet supported for glum (see [this PR](https://github.com/Quantco/glum/pull/482)). Moreover, musllinux wheels increased the runtime of building linux wheels by a significant amount (~15 minutes to > 1 hour).
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] ~~Added a `CHANGELOG.rst` entry~~
