### PR TITLE
Macos test failing on main

### DIFF
--- a/.github/workflows/conda-build-macos.yml
+++ b/.github/workflows/conda-build-macos.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@35d1405e78aa3f784fe3ce9a2eb378d5eeb62169
         with:
           miniforge-variant: Mambaforge
-          miniforge-version: 4.10.0-0
+          miniforge-version: 4.10.3-6
           channels: conda-forge
           use-mamba: true
       - name: Build conda package

--- a/.github/workflows/conda-build-win.yml
+++ b/.github/workflows/conda-build-win.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@35d1405e78aa3f784fe3ce9a2eb378d5eeb62169
         with:
           miniforge-variant: Mambaforge
-          miniforge-version: 4.10.0-0
+          miniforge-version: 4.10.3-6
           use-mamba: true
       - name: Build conda package
         shell: pwsh

--- a/.github/workflows/tests-macos-main.yml
+++ b/.github/workflows/tests-macos-main.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@35d1405e78aa3f784fe3ce9a2eb378d5eeb62169
         with:
           miniforge-variant: Mambaforge
-          miniforge-version: 4.10.0-0
+          miniforge-version: 4.10.3-6
           use-mamba: true
       - name: Run Unit Tests
         shell: bash -l {0}

--- a/.github/workflows/tests-macos.yml
+++ b/.github/workflows/tests-macos.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@35d1405e78aa3f784fe3ce9a2eb378d5eeb62169
         with:
           miniforge-variant: Mambaforge
-          miniforge-version: 4.10.0-0
+          miniforge-version: 4.10.3-6
           use-mamba: true
       - name: Run Unit Tests
         shell: bash -l {0}

--- a/.github/workflows/tests-macos.yml
+++ b/.github/workflows/tests-macos.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@35d1405e78aa3f784fe3ce9a2eb378d5eeb62169
         with:
           miniforge-variant: Mambaforge
-          miniforge-version: 4.10.3-6
+          miniforge-version: 4.10.0-0
           use-mamba: true
       - name: Run Unit Tests
         shell: bash -l {0}

--- a/.github/workflows/tests-win-main.yml
+++ b/.github/workflows/tests-win-main.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           python-version: ${{ matrix.PYTHON_VERSION }}
           miniforge-variant: Mambaforge
-          miniforge-version: 4.10.0-0
+          miniforge-version: 4.10.3-6
           use-mamba: true
           environment-file: environment-win.yml
           activate-environment: tabmat

--- a/.github/workflows/tests-win.yml
+++ b/.github/workflows/tests-win.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           python-version: ${{ matrix.PYTHON_VERSION }}
           miniforge-variant: Mambaforge
-          miniforge-version: 4.10.0-0
+          miniforge-version: 4.10.3-6
           use-mamba: true
           environment-file: environment-win.yml
           activate-environment: tabmat


### PR DESCRIPTION
Somehow the CI for the macos test when pushed to main was not updated at the same time that the same "normal" tests were updated. The culprit was an old version of mamba that solved the environment using pypy instead of cpython.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] ~~Added a `CHANGELOG.rst` entry~~ (only affects the CI so no changelog)
