### PR TITLE
Test against nightly builds

### DIFF
--- a/.github/actions/unittests/action.yml
+++ b/.github/actions/unittests/action.yml
@@ -4,6 +4,15 @@ inputs:
   python_version:
     description: 'Python version'
     required: true
+  pandas_version:
+    description: 'Pandas version'
+    required: false
+  numpy_version:
+    description: 'Numpy version'
+    required: false
+  scipy_version:
+    description: 'Scipy version'
+    required: false
 runs:
   using: 'docker'
   image: condaforge/mambaforge:latest
@@ -11,4 +20,4 @@ runs:
    - /bin/bash
    - "-l"
    - "-c"
-   - "./.github/workflows/test.sh ${{ inputs.python_version }}"
+   - "PYTHON_VERSION=${{ inputs.python_version }} PANDAS_VERSION=${{ inputs.pandas_version }} NUMPY_VERSION=${{ inputs.numpy_version }} SCIPY_VERSION=${{ inputs.scipy_version }} ./.github/workflows/test.sh"

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1,0 +1,64 @@
+name: Daily runs
+on:
+  schedule:
+    - cron: '0 5 * * *'
+  push:
+    paths:
+    - '.github/workflows/daily.yml'
+
+jobs:
+  linux-daily-unittests:
+    name: "Linux - daily unit tests - Python ${{ matrix.PYTHON_VERSION}} - ${{ matrix.NOTE }}"
+    runs-on: ubuntu-latest
+    env:
+      CI: True
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - PYTHON_VERSION: '3.9'
+            PANDAS_VERSION: 'nightly'
+            NUMPY_VERSION: 'nightly'
+            SCIPY_VERSION: 'nightly'
+            NOTE: 'Nightly Builds' # run once with nightlies
+          - PYTHON_VERSION: '3.9'
+            PANDAS_VERSION: ''
+            NUMPY_VERSION: ''
+            SCIPY_VERSION: ''
+            NOTE: 'Default Builds' # run once with normal dependencies
+    steps:
+      - name: Pull image
+        run: docker pull condaforge/mambaforge:latest
+      - name: Checkout branch
+        uses: actions/checkout@v2.3.5
+        with:
+          ref: ${{ github.head_ref }}
+      - name: Run CI inside of container
+        uses: ./.github/actions/unittests
+        with:
+          python_version: ${{ matrix.PYTHON_VERSION }}
+          pandas_version: ${{ matrix.PANDAS_VERSION }}
+          numpy_version: ${{ matrix.NUMPY_VERSION }}
+          scipy_version: ${{ matrix.SCIPY_VERSION }}
+      - name: Issue on failure
+        uses: actions/github-script@v5
+        if: ${{ failure() }}
+        with:
+          script: |
+            github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "open",
+              labels: "[bot] Daily run"
+            }).then((issues) => {
+              if (issues.data.length === 0){
+                github.rest.issues.create({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  title: "Daily run failure: Unit tests",
+                  body: "The daily unit tests failed. See https://github.com/Quantco/tabmat/actions/runs/${{ github.run_id }} for details.",
+                  assignees: ["MarcAntoineSchmidtQC"],
+                  labels: ["[bot] Daily run"]
+                })
+              }
+            });

--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -3,16 +3,43 @@
 set -exo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-source ${SCRIPT_DIR}/base.sh $*
+source ${SCRIPT_DIR}/base.sh "$PYTHON_VERSION"
 
 mamba install -y yq
-yq -Y ". + {dependencies: [.dependencies[], \"python=${PYTHON_VERSION}\"] }" environment.yml > /tmp/environment.yml
+
+cat environment.yml > /tmp/environment.yml
+
+# pin version of some libraries, if specified
+LIBRARIES=("python" "pandas" "numpy" "scipy")
+for library in "${LIBRARIES[@]}"; do
+    varname="${library^^}_VERSION"
+    version=${!varname}
+    if [[ -n "$version" && "$version" != "nightly" ]]; then
+        yq -Y --in-place ". + {dependencies: [.dependencies[], \"${library}=${version}\"]}" /tmp/environment.yml
+    fi
+done
+
+cat /tmp/environment.yml
+
 mamba env create -f /tmp/environment.yml
 conda activate $(yq -r .name environment.yml)
+
+PRE_WHEELS="https://pypi.anaconda.org/scipy-wheels-nightly/simple"
+if [[ "$NUMPY_VERSION" == "nightly" ]]; then
+    echo "Installing Numpy nightly"
+    conda uninstall -y --force numpy
+    pip install --pre --no-deps --upgrade --timeout=60 -i $PRE_WHEELS numpy
+fi
+if [[ "$PANDAS_VERSION" == "nightly" ]]; then
+    echo "Installing Pandas nightly"
+    conda uninstall -y --force pandas
+    pip install --pre --no-deps --upgrade --timeout=60 -i $PRE_WHEELS pandas
+fi
+if [[ "$SCIPY_VERSION" == "nightly" ]]; then
+    echo "Installing Scipy nightly"
+    conda uninstall -y --force scipy
+    pip install --pre --no-deps --upgrade --timeout=60 -i $PRE_WHEELS scipy
+fi
+
 pip install --no-use-pep517 --no-deps --disable-pip-version-check -e .
 pytest -nauto tests --doctest-modules src/
-
-# TODO: Add sphinx documentation
-# pushd $(pwd)/docs
-# make html
-# popd


### PR DESCRIPTION
This adds a daily CI job to our test suite that test against nightlies of pandas, scipy, and numpy (linux only).

Same as https://github.com/Quantco/glum/pull/502