### PR TITLE
implementation of `CategoricalMatrix` with drop_first

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,13 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+**New feature**
+
+- :class:`tabmat.CategoricalMatrix` now accepts a `drop_first` argurment. This allows the user to drop the first column of a CategoricalMatrix to avoid multicollinearity problems in unregularized models.
+
 3.0.8 - 2022-01-03
 ------------------
 
@@ -194,6 +201,7 @@ We are trying to make releases for Windows.
 **Other changes:**
 
 - Added various tests and documentation improvements
+
 
 1.0.0 - 2020-11-11
 ------------------

--- a/src/tabmat/categorical_matrix.py
+++ b/src/tabmat/categorical_matrix.py
@@ -167,7 +167,14 @@ import numpy as np
 import pandas as pd
 from scipy import sparse as sps
 
-from .ext.categorical import matvec, sandwich_categorical, transpose_matvec
+from .ext.categorical import (
+    matvec,
+    matvec_drop_first,
+    sandwich_categorical,
+    sandwich_categorical_drop_first,
+    transpose_matvec,
+    transpose_matvec_drop_first,
+)
 from .ext.split import sandwich_cat_cat, sandwich_cat_dense
 from .matrix_base import MatrixBase
 from .sparse_matrix import SparseMatrix
@@ -212,12 +219,18 @@ class CategoricalMatrix(MatrixBase):
     cat_vec:
         array-like vector of categorical data.
 
+    drop_first:
+        drop the first level of the dummy encoding. This allows a CategoricalMatrix
+        to be used in an unregularized setting.
+
     dtype:
+        data type
     """
 
     def __init__(
         self,
         cat_vec: Union[List, np.ndarray, pd.Categorical],
+        drop_first: bool = False,
         dtype: np.dtype = np.float64,
     ):
         if pd.isnull(cat_vec).any():
@@ -228,7 +241,8 @@ class CategoricalMatrix(MatrixBase):
         else:
             self.cat = pd.Categorical(cat_vec)
 
-        self.shape = (len(self.cat), len(self.cat.categories))
+        self.drop_first = drop_first
+        self.shape = (len(self.cat), len(self.cat.categories) - int(drop_first))
         self.indices = self.cat.codes.astype(np.int32)
         self.x_csc: Optional[Tuple[Optional[np.ndarray], np.ndarray, np.ndarray]] = None
         self.dtype = np.dtype(dtype)
@@ -299,7 +313,13 @@ class CategoricalMatrix(MatrixBase):
         if out is None:
             out = np.zeros(self.shape[0], dtype=other_m.dtype)
 
-        matvec(self.indices, other_m, self.shape[0], cols, self.shape[1], out)
+        if self.drop_first:
+            matvec_drop_first(
+                self.indices, other_m, self.shape[0], cols, self.shape[1], out
+            )
+        else:
+            matvec(self.indices, other_m, self.shape[0], cols, self.shape[1], out)
+
         if is_int:
             return out.astype(int)
         return out
@@ -359,7 +379,15 @@ class CategoricalMatrix(MatrixBase):
         if cols is not None:
             cols = set_up_rows_or_cols(cols, self.shape[1])
 
-        transpose_matvec(self.indices, vec, self.shape[1], vec.dtype, rows, cols, out)
+        if self.drop_first:
+            transpose_matvec_drop_first(
+                self.indices, vec, self.shape[1], vec.dtype, rows, cols, out
+            )
+        else:
+            transpose_matvec(
+                self.indices, vec, self.shape[1], vec.dtype, rows, cols, out
+            )
+
         if out_is_none and cols is not None:
             return out[cols, ...]  # type: ignore
         return out
@@ -387,7 +415,15 @@ class CategoricalMatrix(MatrixBase):
         """
         d = np.asarray(d)
         rows = set_up_rows_or_cols(rows, self.shape[0])
-        res_diag = sandwich_categorical(self.indices, d, rows, d.dtype, self.shape[1])
+        if self.drop_first:
+            res_diag = sandwich_categorical_drop_first(
+                self.indices, d, rows, d.dtype, self.shape[1]
+            )
+        else:
+            res_diag = sandwich_categorical(
+                self.indices, d, rows, d.dtype, self.shape[1]
+            )
+
         if cols is not None and len(cols) < self.shape[1]:
             res_diag = res_diag[cols]
         return sps.diags(res_diag)
@@ -422,6 +458,11 @@ class CategoricalMatrix(MatrixBase):
         # TODO: data should be uint8
         data = np.ones(self.shape[0], dtype=int)
 
+        if self.drop_first:
+            return sps.csr_matrix(
+                (data, self.indices, np.arange(self.shape[0] + 1, dtype=int)),
+                shape=(self.shape[0], self.shape[1] + 1),
+            )[:, 1:]
         return sps.csr_matrix(
             (data, self.indices, np.arange(self.shape[0] + 1, dtype=int)),
             shape=self.shape,
@@ -451,7 +492,9 @@ class CategoricalMatrix(MatrixBase):
             if _is_indexer_full_length(self.shape[1], col):
                 if isinstance(row, int):
                     row = [row]
-                return CategoricalMatrix(self.cat[row])
+                return CategoricalMatrix(
+                    self.cat[row], drop_first=self.drop_first, dtype=self.dtype
+                )
             else:
                 # return a SparseMatrix if we subset columns
                 # TODO: this is inefficient. See issue #101.
@@ -460,7 +503,9 @@ class CategoricalMatrix(MatrixBase):
             row = item
         if isinstance(row, int):
             row = [row]
-        return CategoricalMatrix(self.cat[row])
+        return CategoricalMatrix(
+            self.cat[row], drop_first=self.drop_first, dtype=self.dtype
+        )
 
     def _cross_dense(
         self,
@@ -483,10 +528,16 @@ class CategoricalMatrix(MatrixBase):
         rows, R_cols = setup_restrictions((self.shape[0], other.shape[1]), rows, R_cols)
 
         res = sandwich_cat_dense(
-            self.indices, self.shape[1], d, other, rows, R_cols, is_c_contiguous
+            self.indices,
+            self.shape[1] + self.drop_first,
+            d,
+            other,
+            rows,
+            R_cols,
+            is_c_contiguous,
         )
 
-        res = res[_none_to_slice(L_cols, self.shape[1]), :]
+        res = res[self.drop_first :][_none_to_slice(L_cols, self.shape[1]), :]
         return res
 
     def _cross_categorical(
@@ -505,12 +556,19 @@ class CategoricalMatrix(MatrixBase):
         rows = set_up_rows_or_cols(rows, self.shape[0])
 
         res = sandwich_cat_cat(
-            i_indices, j_indices, self.shape[1], other.shape[1], d, rows, d.dtype
+            i_indices,
+            j_indices,
+            self.shape[1] + self.drop_first,
+            other.shape[1] + other.drop_first,
+            d,
+            rows,
+            d.dtype,
         )
 
         L_cols = _none_to_slice(L_cols, self.shape[1])
         R_cols = _none_to_slice(R_cols, other.shape[1])
-        res = res[L_cols, :][:, R_cols]
+
+        res = res[self.drop_first :, other.drop_first :][L_cols, :][:, R_cols]
         return res
 
     def _cross_sparse(
@@ -521,13 +579,14 @@ class CategoricalMatrix(MatrixBase):
         L_cols: Optional[np.ndarray],
         R_cols: Optional[np.ndarray],
     ) -> np.ndarray:
-
-        term_1 = self.tocsr()
-        term_1.data = term_1.data * d
+        term_1 = sps.csr_matrix(
+            (d, self.indices, np.arange(self.shape[0] + 1, dtype=int)),
+            shape=(self.shape[0], self.shape[1] + self.drop_first),
+        )
 
         rows = _none_to_slice(rows, self.shape[0])
         L_cols = _none_to_slice(L_cols, self.shape[1])
-        term_1 = term_1[rows, :][:, L_cols]
+        term_1 = term_1[:, self.drop_first :][rows, :][:, L_cols]
 
         res = term_1.T.dot(other[rows, :][:, _none_to_slice(R_cols, other.shape[1])]).A
 
@@ -539,6 +598,16 @@ class CategoricalMatrix(MatrixBase):
             raise ValueError(
                 f"Shapes do not match. Expected length of {self.shape[0]}. Got {len(other)}."
             )
+
+        if self.drop_first:
+            return sps.csr_matrix(
+                (
+                    np.squeeze(other),
+                    self.indices,
+                    np.arange(self.shape[0] + 1, dtype=int),
+                ),
+                shape=(self.shape[0], self.shape[1] + 1),
+            )[:, 1:]
 
         return sps.csr_matrix(
             (np.squeeze(other), self.indices, np.arange(self.shape[0] + 1, dtype=int)),

--- a/src/tabmat/constructor.py
+++ b/src/tabmat/constructor.py
@@ -20,6 +20,7 @@ def from_pandas(
     cat_threshold: int = 4,
     object_as_cat: bool = False,
     cat_position: str = "expand",
+    drop_first: bool = False,
 ) -> MatrixBase:
     """
     Transform a pandas.DataFrame into an efficient SplitMatrix. For most users, this
@@ -45,6 +46,10 @@ def from_pandas(
         categoricals (including the ones that did not satisfy cat_threshold)
         will be placed at the end of the index list. If "expand", all the variables
         will remain in the same order.
+    drop_first : bool, default False
+        If true, categoricals variables will have their first category dropped.
+        This allows multiple categorical variables to be included in an
+        unregularized model. If False, all categories are included.
 
     Returns
     -------
@@ -75,7 +80,11 @@ def from_pandas(
                     sparse_indices,
                 ) = _split_sparse_and_dense_parts(
                     pd.get_dummies(
-                        coldata, prefix=colname, sparse=True, dtype=np.float64
+                        coldata,
+                        prefix=colname,
+                        sparse=True,
+                        drop_first=drop_first,
+                        dtype=np.float64,
                     )
                     .sparse.to_coo()
                     .tocsc(),
@@ -94,7 +103,7 @@ def from_pandas(
                     indices.append(sparse_indices)
 
             else:
-                cat = CategoricalMatrix(coldata, dtype=dtype)
+                cat = CategoricalMatrix(coldata, drop_first=drop_first, dtype=dtype)
                 matrices.append(cat)
                 is_cat.append(True)
                 if cat_position == "expand":

--- a/src/tabmat/dense_matrix.py
+++ b/src/tabmat/dense_matrix.py
@@ -92,7 +92,7 @@ class DenseMatrix(np.ndarray, MatrixBase):
         vec: Union[List, np.ndarray],
         rows: Optional[np.ndarray],
         cols: Optional[np.ndarray],
-        out: Optional[Union[np.ndarray]],
+        out: Optional[np.ndarray],
         transpose: bool,
     ):
         # Because the dense_rmatvec takes a row array and col array, it has

--- a/src/tabmat/ext/cat_split_helpers-tmpl.cpp
+++ b/src/tabmat/ext/cat_split_helpers-tmpl.cpp
@@ -42,7 +42,9 @@ void _sandwich_cat_cat(
     int len_rows,
     F* res,
     int res_n_col,
-    int res_size
+    int res_size,
+    bool i_drop_first,
+    bool j_drop_first
 )
 {
     #pragma omp parallel
@@ -51,11 +53,17 @@ void _sandwich_cat_cat(
         # pragma omp for
         for (int k_idx = 0; k_idx < len_rows; k_idx++) {
             int k = rows[k_idx];
-            int i = i_indices[k];
-            int j = j_indices[k];
+            int i = i_indices[k] - i_drop_first;
+            if (i == -1) {
+                continue;
+            }
+            int j = j_indices[k] - j_drop_first;
+            if (j == -1) {
+                continue;
+            }
             restemp[i * res_n_col + j] += d[k];
         }
-        for (int i = 0; i < res_size; i ++) {
+        for (int i = 0; i < res_size; i++) {
             # pragma omp atomic
             res[i] += restemp[i];
         }

--- a/src/tabmat/ext/cat_split_helpers-tmpl.cpp
+++ b/src/tabmat/ext/cat_split_helpers-tmpl.cpp
@@ -1,8 +1,9 @@
 #include <vector>
 
 
+<%def name="transpose_matvec(dropfirst)">
 template <typename F>
-void _transpose_matvec_all_rows(
+void _transpose_matvec_${dropfirst}(
     int n_rows,
     int* indices,
     F* other,
@@ -14,7 +15,14 @@ void _transpose_matvec_all_rows(
         std::vector<F> restemp(res_size, 0.0);
         #pragma omp for
         for (int i = 0; i < n_rows; i++) {
-            restemp[indices[i]] += other[i];
+            % if dropfirst == 'all_rows_drop_first':
+                int col_idx = indices[i] - 1;
+                if (col_idx != -1) {
+                    restemp[col_idx] += other[i];
+                }
+            % else:
+                restemp[indices[i]] += other[i];
+            % endif
         }
         for (int i = 0; i < res_size; i++) {
             # pragma omp atomic
@@ -22,6 +30,7 @@ void _transpose_matvec_all_rows(
         }
     }
 }
+</%def>
 
 
 template <typename F>
@@ -101,3 +110,5 @@ void _sandwich_cat_dense${order}(
 
 ${sandwich_cat_dense_tmpl('C')}
 ${sandwich_cat_dense_tmpl('F')}
+${transpose_matvec('all_rows')}
+${transpose_matvec('all_rows_drop_first')}

--- a/src/tabmat/ext/categorical.pyx
+++ b/src/tabmat/ext/categorical.pyx
@@ -15,10 +15,18 @@ from libcpp cimport bool
 
 cdef extern from "cat_split_helpers.cpp":
     void _transpose_matvec_all_rows[F](int, int*, F*, F*, int)
+    void _transpose_matvec_all_rows_drop_first[F](int, int*, F*, F*, int)
 
 
-def transpose_matvec(int[:] indices, floating[:] other, int n_cols, dtype,
-                  rows, cols, floating[:] out):
+def transpose_matvec(
+    int[:] indices,
+    floating[:] other,
+    int n_cols,
+    dtype,
+    rows,
+    cols,
+    floating[:] out
+):
     cdef int row, row_idx, n_keep_rows, col
     cdef int n_rows = len(indices)
     cdef int[:] rows_view, cols_view, cols_included
@@ -57,6 +65,55 @@ def transpose_matvec(int[:] indices, floating[:] other, int n_cols, dtype,
                     out[col] += other[row]
 
 
+def transpose_matvec_drop_first(
+    int[:] indices,
+    floating[:] other,
+    int n_cols,
+    dtype,
+    rows,
+    cols,
+    floating[:] out
+):
+    cdef int row, row_idx, n_keep_rows, col_idx
+    cdef int n_rows = len(indices)
+    cdef int[:] rows_view, cols_view, cols_included
+
+    cdef bool no_row_restrictions = rows is None or len(rows) == n_rows
+    cdef bool no_col_restrictions = cols is None or len(cols) == n_cols
+
+    # Case 1: No row or col restrictions
+    if no_row_restrictions and no_col_restrictions:
+        _transpose_matvec_all_rows_drop_first(n_rows, &indices[0], &other[0], &out[0], out.size)
+    # Case 2: row restrictions but no col restrictions
+    elif no_col_restrictions:
+        rows_view = rows
+        n_keep_rows = len(rows_view)
+        for row_idx in range(n_keep_rows):
+            row = rows_view[row_idx]
+            col_idx = indices[row] - 1
+            if col_idx != -1:
+                out[col_idx] += other[row]
+    # Cases 3 and 4: col restrictions
+    else:
+        cols_view = cols
+        cols_included = get_col_included(cols, n_cols)
+        # Case 3: Col restrictions but no row restrictions
+        if no_row_restrictions:
+            for row_idx in range(n_rows):
+                col_idx = indices[row_idx] - 1
+                if (col_idx != -1) and (cols_included[col_idx]):
+                    out[col_idx] += other[row_idx]
+        # Case 4: Both col restrictions and row restrictions
+        else:
+            rows_view = rows
+            n_keep_rows = len(rows_view)
+            for row_idx in range(n_keep_rows):
+                row = rows_view[row_idx]
+                col_idx = indices[row] - 1
+                if (col_idx != -1) and (cols_included[col_idx]):
+                    out[col_idx] += other[row]
+
+
 def get_col_included(int[:] cols, int n_cols):
     cdef int[:] col_included = np.zeros(n_cols, dtype=np.int32)
     cdef int n_cols_included = len(cols)
@@ -65,9 +122,18 @@ def get_col_included(int[:] cols, int n_cols):
     return col_included
 
 
-def matvec(const int[:] indices, floating[:] other, int n_rows, int[:] cols,
-        int n_cols, floating[:] out_vec):
-    cdef int i, col, Ci, k
+def matvec(
+    const int[:] indices,
+    floating[:] other,
+    int n_rows,
+    int[:] cols,
+    int n_cols,
+    floating[:] out_vec
+):
+    """Matrix-vector multiplication. With one-hot-encoded data,
+    this is equivalent to `other[cat_index]`.
+    """
+    cdef int i, col_idx, Ci, k
     cdef int[:] col_included
 
     if cols is None:
@@ -76,22 +142,72 @@ def matvec(const int[:] indices, floating[:] other, int n_rows, int[:] cols,
     else:
         col_included = get_col_included(cols, n_cols)
         for i in prange(n_rows, nogil=True):
-            col = indices[i]
-            if col_included[col] == 1:
-                out_vec[i] += other[indices[i]]
+            col_idx = indices[i]
+            if col_included[col_idx] == 1:
+                out_vec[i] += other[col_idx]
     return
 
 
+def matvec_drop_first(
+    const int[:] indices, 
+    floating[:] other, 
+    int n_rows, 
+    int[:] cols,
+    int n_cols, 
+    floating[:] out_vec
+):
+    """See `matvec`. Here we drop the first category of the
+    CategoricalMatrix so the indices refer to the column index + 1.
+    """
+    cdef int i, col_idx, Ci, k
+    cdef int[:] col_included
 
-def sandwich_categorical(const int[:] indices, floating[:] d,
-                        int[:] rows, dtype, int n_cols):
+    if cols is None:
+        for i in prange(n_rows, nogil=True):
+            col_idx = indices[i] - 1  # reference category is always 0.
+            if col_idx != -1:
+                out_vec[i] += other[col_idx]
+    else:
+        col_included = get_col_included(cols, n_cols)
+        for i in prange(n_rows, nogil=True):
+            col_idx = indices[i] - 1
+            if (col_idx != -1) and (col_included[col_idx] == 1):
+                out_vec[i] += other[col_idx]
+    return
+
+
+def sandwich_categorical(
+    const int[:] indices,
+    floating[:] d,
+    int[:] rows,
+    dtype,
+    int n_cols
+):
     cdef floating[:] res = np.zeros(n_cols, dtype=dtype)
-    cdef int i, k, k_idx
+    cdef int col_idx, k, k_idx
     cdef int n_rows = len(rows)
 
     for k_idx in range(n_rows):
         k = rows[k_idx]
-        i = indices[k]
-        res[i] += d[k]
+        col_idx = indices[k]
+        res[col_idx] += d[k]
     return np.asarray(res)
 
+
+def sandwich_categorical_drop_first(
+    const int[:] indices,
+    floating[:] d,
+    int[:] rows,
+    dtype,
+    int n_cols
+):
+    cdef floating[:] res = np.zeros(n_cols, dtype=dtype)
+    cdef int col_idx, k, k_idx
+    cdef int n_rows = len(rows)
+
+    for k_idx in range(n_rows):
+        k = rows[k_idx]
+        col_idx = indices[k] - 1  # reference category is always 0.
+        if col_idx != -1:
+            res[col_idx] += d[k]
+    return np.asarray(res)

--- a/src/tabmat/ext/split.pyx
+++ b/src/tabmat/ext/split.pyx
@@ -24,7 +24,7 @@ ctypedef fused win_integral:
 cdef extern from "cat_split_helpers.cpp":
     void _sandwich_cat_denseC[F](F*, int*, int*, int, int*, int, F*, int, F*, int, int) nogil
     void _sandwich_cat_denseF[F](F*, int*, int*, int, int*, int, F*, int, F*, int, int) nogil
-    void _sandwich_cat_cat[F](F*, const int*, const int*, int*, int, F*, int, int)
+    void _sandwich_cat_cat[F](F*, const int*, const int*, int*, int, F*, int, int, bool, bool)
 
 
 def sandwich_cat_dense(
@@ -69,7 +69,9 @@ def sandwich_cat_cat(
     int j_ncol,
     floating[:] d,
     int[:] rows,
-    dtype
+    dtype,
+    bint i_drop_first,
+    bint j_drop_first
 ):
     """
     (X1.T @ diag(d) @ X2)[i, j] = sum_k X1[k, i] d[k] X2[k, j]
@@ -77,7 +79,7 @@ def sandwich_cat_cat(
     cdef floating[:, :] res = np.zeros((i_ncol, j_ncol), dtype=dtype)
 
     _sandwich_cat_cat(&d[0], &i_indices[0], &j_indices[0], &rows[0], len(rows),
-                        &res[0, 0], j_ncol, res.size)
+                        &res[0, 0], j_ncol, res.size, i_drop_first, j_drop_first)
 
     return np.asarray(res)
 

--- a/tests/test_split_matrix.py
+++ b/tests/test_split_matrix.py
@@ -71,7 +71,7 @@ def get_split_with_cat_components() -> List[
     cat = tm.CategoricalMatrix(np.random.choice(range(3), n_rows))
     dense_2 = tm.DenseMatrix(np.random.random((n_rows, 3)))
     sparse_2 = tm.SparseMatrix(sps.random(n_rows, 3, density=0.5).tocsc())
-    cat_2 = tm.CategoricalMatrix(np.random.choice(range(3), n_rows))
+    cat_2 = tm.CategoricalMatrix(np.random.choice(range(3), n_rows), drop_first=True)
     return [dense_1, sparse_1, cat, dense_2, sparse_2, cat_2]
 
 


### PR DESCRIPTION
closes #75.

Description
------------

This P.R. adds the functionality to "drop" the first level of a `CategoricalMatrix`. With unregularized models having also an intercept, this is necessary to maintain a full rank design matrix.

I decided to always drop the first level. A user could always reorder the categories manually to have the correct reference level.

Future work?
-------------

Some operations could be optimized. For example, all the `_cross_sandwich` operations are done by simply computing the result without dropping a level, and then to drop the first row/column or the resulting output matrix. I would merge this in as-is since I think changing this will significantly complexify the codebase with a minimal improvement in performance.

Still an open question: how do we make this feature available in the `from_pandas` function and in glum?

Tests
-----

I've modified the tests so that one of the `CategoricalMatrix` component of the testing suite drops a level. I've also added a parametrization to most of the tests in `test_categorical_matrix.py` to check for this new feature. I didn't create any new test.


<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a `CHANGELOG.rst` entry
