### PR TITLE
Multiply method

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,8 @@ Unreleased
 **New feature**
 
 - :class:`tabmat.CategoricalMatrix` now accepts a `drop_first` argurment. This allows the user to drop the first column of a CategoricalMatrix to avoid multicollinearity problems in unregularized models.
+- :class:`tabmat.StandardizedMatrix` and :class:`tabmat.MatrixBase` now support the `multiply` method.
+
 
 3.0.8 - 2022-01-03
 ------------------

--- a/src/tabmat/categorical_matrix.py
+++ b/src/tabmat/categorical_matrix.py
@@ -607,7 +607,7 @@ class CategoricalMatrix(MatrixBase):
     def multiply(self, other) -> SparseMatrix:
         """Element-wise multiplication.
 
-        This assumes that ``other`` is a vector of size self.shape[1].
+        This assumes that ``other`` is a vector of size self.shape[0].
         """
         if self.shape[0] != other.shape[0]:
             raise ValueError(

--- a/src/tabmat/categorical_matrix.py
+++ b/src/tabmat/categorical_matrix.py
@@ -607,7 +607,7 @@ class CategoricalMatrix(MatrixBase):
     def multiply(self, other) -> SparseMatrix:
         """Element-wise multiplication.
 
-        This assumes that ``other`` is a vector of size self.shape[0].
+        This assumes that ``other`` is a vector of size ``self.shape[0]``.
         """
         if self.shape[0] != other.shape[0]:
             raise ValueError(

--- a/src/tabmat/categorical_matrix.py
+++ b/src/tabmat/categorical_matrix.py
@@ -597,7 +597,7 @@ class CategoricalMatrix(MatrixBase):
         L_cols: Optional[np.ndarray],
         R_cols: Optional[np.ndarray],
     ) -> np.ndarray:
-        term_1 = self * d  # multiply will deal with drop_first
+        term_1 = self.multiply(d)  # multiply will deal with drop_first
 
         term_1 = _row_col_indexing(term_1, rows, L_cols)
 
@@ -637,9 +637,6 @@ class CategoricalMatrix(MatrixBase):
                 shape=self.shape,
             )
         )
-
-    __mul__ = multiply
-    __rmul__ = multiply
 
     def __repr__(self):
         return str(self.cat)

--- a/src/tabmat/categorical_matrix.py
+++ b/src/tabmat/categorical_matrix.py
@@ -604,27 +604,38 @@ class CategoricalMatrix(MatrixBase):
         res = term_1.T.dot(_row_col_indexing(other, rows, R_cols)).A
         return res
 
-    def multiply(self, other) -> sps.csr_matrix:
-        """Element-wise multiplication of each column with other."""
+    def multiply(self, other) -> SparseMatrix:
+        """Element-wise multiplication.
+
+        This assumes that ``other`` is a vector of size self.shape[1].
+        """
         if self.shape[0] != other.shape[0]:
             raise ValueError(
                 f"Shapes do not match. Expected length of {self.shape[0]}. Got {len(other)}."
             )
 
         if self.drop_first:
-            return sps.csr_matrix(
-                multiply_drop_first(
-                    indices=self.indices,
-                    d=np.squeeze(other),
-                    ncols=self.shape[1],
-                    dtype=other.dtype,
+            return SparseMatrix(
+                sps.csr_matrix(
+                    multiply_drop_first(
+                        indices=self.indices,
+                        d=np.squeeze(other),
+                        ncols=self.shape[1],
+                        dtype=other.dtype,
+                    ),
+                    shape=self.shape,
+                )
+            )
+
+        return SparseMatrix(
+            sps.csr_matrix(
+                (
+                    np.squeeze(other),
+                    self.indices,
+                    np.arange(self.shape[0] + 1, dtype=int),
                 ),
                 shape=self.shape,
             )
-
-        return sps.csr_matrix(
-            (np.squeeze(other), self.indices, np.arange(self.shape[0] + 1, dtype=int)),
-            shape=self.shape,
         )
 
     __mul__ = multiply

--- a/src/tabmat/dense_matrix.py
+++ b/src/tabmat/dense_matrix.py
@@ -155,3 +155,15 @@ class DenseMatrix(np.ndarray, MatrixBase):
         """Perform self[:, cols] @ other."""
         check_matvec_out_shape(self, out)
         return self._matvec_helper(vec, None, cols, out, False)
+
+    def multiply(self, other):
+        """Element-wise multiplication.
+
+        This assumes that ``other`` is a vector of size self.shape[1].
+        """
+        if other.ndim == 1:
+            return super().__mul__(other[:, np.newaxis])
+        return super().__mul__(other)
+
+    __mul__ = multiply
+    __rmul__ = multiply

--- a/src/tabmat/dense_matrix.py
+++ b/src/tabmat/dense_matrix.py
@@ -161,9 +161,6 @@ class DenseMatrix(np.ndarray, MatrixBase):
 
         This assumes that ``other`` is a vector of size self.shape[1].
         """
-        if other.ndim == 1:
+        if np.asanyarray(other).ndim == 1:
             return super().__mul__(other[:, np.newaxis])
         return super().__mul__(other)
-
-    __mul__ = multiply
-    __rmul__ = multiply

--- a/src/tabmat/dense_matrix.py
+++ b/src/tabmat/dense_matrix.py
@@ -159,7 +159,7 @@ class DenseMatrix(np.ndarray, MatrixBase):
     def multiply(self, other):
         """Element-wise multiplication.
 
-        This assumes that ``other`` is a vector of size self.shape[0].
+        This assumes that ``other`` is a vector of size ``self.shape[0]``.
         """
         if np.asanyarray(other).ndim == 1:
             return super().__mul__(other[:, np.newaxis])

--- a/src/tabmat/dense_matrix.py
+++ b/src/tabmat/dense_matrix.py
@@ -159,7 +159,7 @@ class DenseMatrix(np.ndarray, MatrixBase):
     def multiply(self, other):
         """Element-wise multiplication.
 
-        This assumes that ``other`` is a vector of size self.shape[1].
+        This assumes that ``other`` is a vector of size self.shape[0].
         """
         if np.asanyarray(other).ndim == 1:
             return super().__mul__(other[:, np.newaxis])

--- a/src/tabmat/sparse_matrix.py
+++ b/src/tabmat/sparse_matrix.py
@@ -207,6 +207,3 @@ class SparseMatrix(sps.csc_matrix, MatrixBase):
         if other.ndim == 1:
             return SparseMatrix(super().multiply(other[:, np.newaxis]))
         return SparseMatrix(super().multiply(other))
-
-    __mul__ = multiply
-    __rmul__ = multiply

--- a/src/tabmat/sparse_matrix.py
+++ b/src/tabmat/sparse_matrix.py
@@ -202,7 +202,7 @@ class SparseMatrix(sps.csc_matrix, MatrixBase):
 
         See ``scipy.sparse.csc_matrix.multiply``. The method is taken almost directly
         from the parent class except that ``other`` is assumed to be a vector of size
-        self.shape[1].
+        self.shape[0].
         """
         if other.ndim == 1:
             return SparseMatrix(super().multiply(other[:, np.newaxis]))

--- a/src/tabmat/sparse_matrix.py
+++ b/src/tabmat/sparse_matrix.py
@@ -196,3 +196,17 @@ class SparseMatrix(sps.csc_matrix, MatrixBase):
     def astype(self, dtype, order="K", casting="unsafe", copy=True):
         """Return SparseMatrix cast to new type."""
         return super(SparseMatrix, self).astype(dtype, casting, copy)
+
+    def multiply(self, other):
+        """Element-wise multiplication.
+
+        See ``scipy.sparse.csc_matrix.multiply``. The method is taken almost directly
+        from the parent class except that ``other`` is assumed to be a vector of size
+        self.shape[1].
+        """
+        if other.ndim == 1:
+            return SparseMatrix(super().multiply(other[:, np.newaxis]))
+        return SparseMatrix(super().multiply(other))
+
+    __mul__ = multiply
+    __rmul__ = multiply

--- a/src/tabmat/sparse_matrix.py
+++ b/src/tabmat/sparse_matrix.py
@@ -202,7 +202,7 @@ class SparseMatrix(sps.csc_matrix, MatrixBase):
 
         See ``scipy.sparse.csc_matrix.multiply``. The method is taken almost directly
         from the parent class except that ``other`` is assumed to be a vector of size
-        self.shape[0].
+        ``self.shape[0]``.
         """
         if other.ndim == 1:
             return SparseMatrix(super().multiply(other[:, np.newaxis]))

--- a/src/tabmat/split_matrix.py
+++ b/src/tabmat/split_matrix.py
@@ -421,7 +421,7 @@ class SplitMatrix(MatrixBase):
     def multiply(self, other):
         """Element-wise multiplication.
 
-        This assumes that ``other`` is a vector of size self.shape[0].
+        This assumes that ``other`` is a vector of size ``self.shape[0]``.
         """
         return SplitMatrix(
             [mat.multiply(other) for mat in self.matrices], indices=self.indices

--- a/src/tabmat/split_matrix.py
+++ b/src/tabmat/split_matrix.py
@@ -436,7 +436,4 @@ class SplitMatrix(MatrixBase):
             )
         return out
 
-    __mul__ = multiply
-    __rmul__ = multiply
-
     __array_priority__ = 13

--- a/src/tabmat/split_matrix.py
+++ b/src/tabmat/split_matrix.py
@@ -418,6 +418,15 @@ class SplitMatrix(MatrixBase):
                 f"Only row indexing is supported. Index passed was {key}."
             )
 
+    def multiply(self, other):
+        """Element-wise multiplication.
+
+        This assumes that ``other`` is a vector of size self.shape[1].
+        """
+        return SplitMatrix(
+            [mat.multiply(other) for mat in self.matrices], indices=self.indices
+        )
+
     def __repr__(self):
         out = "SplitMatrix:"
         for i, mat in enumerate(self.matrices):
@@ -426,5 +435,8 @@ class SplitMatrix(MatrixBase):
                 + mat.__repr__()
             )
         return out
+
+    __mul__ = multiply
+    __rmul__ = multiply
 
     __array_priority__ = 13

--- a/src/tabmat/split_matrix.py
+++ b/src/tabmat/split_matrix.py
@@ -421,7 +421,7 @@ class SplitMatrix(MatrixBase):
     def multiply(self, other):
         """Element-wise multiplication.
 
-        This assumes that ``other`` is a vector of size self.shape[1].
+        This assumes that ``other`` is a vector of size self.shape[0].
         """
         return SplitMatrix(
             [mat.multiply(other) for mat in self.matrices], indices=self.indices

--- a/src/tabmat/standardized_mat.py
+++ b/src/tabmat/standardized_mat.py
@@ -245,7 +245,7 @@ class StandardizedMatrix:
 
         Note that the output of this function is always a DenseMatrix and might
         require a lot more memory. This assumes that ``other`` is a vector of
-        size self.shape[0].
+        size ``self.shape[0]``.
         """
         return DenseMatrix(self.toarray()).multiply(other)
 

--- a/src/tabmat/standardized_mat.py
+++ b/src/tabmat/standardized_mat.py
@@ -248,9 +248,6 @@ class StandardizedMatrix:
         """
         return DenseMatrix(self.toarray()).multiply(other)
 
-    __mul__ = multiply
-    __rmul__ = multiply
-
     def toarray(self) -> np.ndarray:
         """Return array representation of matrix."""
         mat_part = self.mat.A

--- a/src/tabmat/standardized_mat.py
+++ b/src/tabmat/standardized_mat.py
@@ -243,8 +243,9 @@ class StandardizedMatrix:
     def multiply(self, other) -> DenseMatrix:
         """Element-wise multiplication.
 
-        Note that the output of this function is a DenseMatrix and might
-        require a lot more memory.
+        Note that the output of this function is always a DenseMatrix and might
+        require a lot more memory. This assumes that ``other`` is a vector of
+        size self.shape[0].
         """
         return DenseMatrix(self.toarray()).multiply(other)
 

--- a/src/tabmat/standardized_mat.py
+++ b/src/tabmat/standardized_mat.py
@@ -3,6 +3,7 @@ from typing import List, Union
 import numpy as np
 from scipy import sparse as sps
 
+from .dense_matrix import DenseMatrix
 from .matrix_base import MatrixBase
 from .sparse_matrix import SparseMatrix
 from .util import (
@@ -22,7 +23,7 @@ class StandardizedMatrix:
 
     ::
 
-        self[i, j] = self.mult[j] * (self.mat[i, j] + self.shift[j])
+        self[i, j] = (self.mult[j] * self.mat[i, j]) + self.shift[j]
 
     This class is returned from
     :meth:`MatrixBase.standardize <tabmat.MatrixBase.standardize>`.
@@ -238,6 +239,17 @@ class StandardizedMatrix:
     def __matmul__(self, other):
         """Define the behavior of 'self @ other'."""
         return self.matvec(other)
+
+    def multiply(self, other) -> DenseMatrix:
+        """Element-wise multiplication.
+
+        Note that the output of this function is a DenseMatrix and might
+        require a lot more memory.
+        """
+        return DenseMatrix(self.toarray()).multiply(other)
+
+    __mul__ = multiply
+    __rmul__ = multiply
 
     def toarray(self) -> np.ndarray:
         """Return array representation of matrix."""

--- a/tests/test_categorical_matrix.py
+++ b/tests/test_categorical_matrix.py
@@ -51,11 +51,9 @@ def test_transpose_matvec(cat_vec, drop_first):
 def test_multiply(cat_vec, drop_first):
     cat_mat = CategoricalMatrix(cat_vec, drop_first=drop_first)
     other = np.arange(len(cat_vec))[:, None]
-    res = cat_mat * other
-    res2 = cat_mat.multiply(other)
+    actual = cat_mat.multiply(other)
     expected = pd.get_dummies(cat_vec, drop_first=drop_first) * other
-    np.testing.assert_allclose(res.A, expected)
-    np.testing.assert_allclose(res2.A, expected)
+    np.testing.assert_allclose(actual.A, expected)
 
 
 @pytest.mark.parametrize("mi_element", [np.nan, None])

--- a/tests/test_matrices.py
+++ b/tests/test_matrices.py
@@ -595,9 +595,7 @@ def test_multiply(mat):
     expected = mat.A * other[:, np.newaxis]
     actual = []
     actual.append(mat.multiply(other))
-    actual.append(mat * other)
     actual.append(mat.multiply(other[:, np.newaxis]))
-    actual.append(mat * other[:, np.newaxis])
 
     for act in actual:
         assert isinstance(act, MatrixBase)

--- a/tests/test_matrices.py
+++ b/tests/test_matrices.py
@@ -7,6 +7,7 @@ import pytest
 from scipy import sparse as sps
 
 import tabmat as tm
+from tabmat.matrix_base import MatrixBase
 
 
 def base_array(order="F") -> np.ndarray:
@@ -586,3 +587,18 @@ def test_split_matrix_creation(mat):
     sm = tm.SplitMatrix(matrices=[mat, mat])
     assert sm.shape[0] == mat.shape[0]
     assert sm.shape[1] == 2 * mat.shape[1]
+
+
+@pytest.mark.parametrize("mat", get_matrices())
+def test_multiply(mat):
+    other = np.arange(mat.shape[0])
+    expected = mat.A * other[:, np.newaxis]
+    actual = []
+    actual.append(mat.multiply(other))
+    actual.append(mat * other)
+    actual.append(mat.multiply(other[:, np.newaxis]))
+    actual.append(mat * other[:, np.newaxis])
+
+    for act in actual:
+        assert isinstance(act, MatrixBase)
+        np.testing.assert_allclose(act.A, expected)


### PR DESCRIPTION
This PR adds a `multiply` method ~~and the `__mul__` and `__rmul__` special methods~~ to the matrices. This is needed for [this glum PR](https://github.com/Quantco/glum/pull/526).

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a `CHANGELOG.rst` entry
