### PR TITLE
Fix issue 181.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,11 @@ jobs:
     steps:
      - name: Pull image
        run: docker pull condaforge/mambaforge:latest
-     - name: Trust My Directory
-       run: export GIT_CEILING_DIRECTORIES=/github
      - name: Checkout branch
        uses: actions/checkout@v3.0.2
        with:
-         fetch-depth: 0
+         ref: ${{ github.head_ref }}
+         set-safe-directory: "/github/workspace"
      - name: Run linter inside of container
        uses: ./.github/actions/linter
   linux:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
      - name: Checkout branch
        uses: actions/checkout@v3
        with:
-         ref: ${{ github.head_ref }}
+         fetch-depth: 0
      - name: Run linter inside of container
        uses: ./.github/actions/linter
   linux:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
      - name: Pull image
        run: docker pull condaforge/mambaforge:latest
+     - name: Trust My Directory
+       run: export GIT_CEILING_DIRECTORIES=/github
      - name: Checkout branch
        uses: actions/checkout@v3.0.2
        with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,9 @@ jobs:
      - name: Pull image
        run: docker pull condaforge/mambaforge:latest
      - name: Checkout branch
-       uses: actions/checkout@v3.0.2
+       uses: actions/checkout@v3
        with:
          ref: ${{ github.head_ref }}
-         set-safe-directory: "/github/workspace"
      - name: Run linter inside of container
        uses: ./.github/actions/linter
   linux:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
      - name: Pull image
        run: docker pull condaforge/mambaforge:latest
      - name: Checkout branch
-       uses: actions/checkout@v3
+       uses: actions/checkout@v3.0.2
        with:
          fetch-depth: 0
      - name: Run linter inside of container

--- a/.github/workflows/pre-commit.sh
+++ b/.github/workflows/pre-commit.sh
@@ -9,6 +9,8 @@ pwd
 
 ls -a
 
+git status
+
 mamba install -y pre-commit
 pre-commit install
 pre-commit run -a

--- a/.github/workflows/pre-commit.sh
+++ b/.github/workflows/pre-commit.sh
@@ -5,11 +5,7 @@ set -exo pipefail
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source ${SCRIPT_DIR}/base.sh $*
 
-pwd
-
-ls -a
-
-git version
+git config --global --add safe.directory /github/workspace
 
 mamba install -y pre-commit
 pre-commit install

--- a/.github/workflows/pre-commit.sh
+++ b/.github/workflows/pre-commit.sh
@@ -5,6 +5,10 @@ set -exo pipefail
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source ${SCRIPT_DIR}/base.sh $*
 
+pwd
+
+ls -a
+
 mamba install -y pre-commit
 pre-commit install
 pre-commit run -a

--- a/.github/workflows/pre-commit.sh
+++ b/.github/workflows/pre-commit.sh
@@ -5,7 +5,6 @@ set -exo pipefail
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source ${SCRIPT_DIR}/base.sh $*
 
-git config --global --add safe.directory /github/workspace
 
 mamba install -y pre-commit
 pre-commit install

--- a/.github/workflows/pre-commit.sh
+++ b/.github/workflows/pre-commit.sh
@@ -5,6 +5,7 @@ set -exo pipefail
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source ${SCRIPT_DIR}/base.sh $*
 
+git config --global --add safe.directory /github/workspace
 
 mamba install -y pre-commit
 pre-commit install

--- a/.github/workflows/pre-commit.sh
+++ b/.github/workflows/pre-commit.sh
@@ -9,7 +9,7 @@ pwd
 
 ls -a
 
-git status
+git version
 
 mamba install -y pre-commit
 pre-commit install

--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -41,5 +41,7 @@ if [[ "$SCIPY_VERSION" == "nightly" ]]; then
     pip install --pre --no-deps --upgrade --timeout=60 -i $PRE_WHEELS scipy
 fi
 
+git fsck
+
 pip install --no-use-pep517 --no-deps --disable-pip-version-check -e .
 pytest -nauto tests --doctest-modules src/

--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -41,7 +41,7 @@ if [[ "$SCIPY_VERSION" == "nightly" ]]; then
     pip install --pre --no-deps --upgrade --timeout=60 -i $PRE_WHEELS scipy
 fi
 
-git fsck
+git config --global --add safe.directory /github/workspace
 
 pip install --no-use-pep517 --no-deps --disable-pip-version-check -e .
 pytest -nauto tests --doctest-modules src/


### PR DESCRIPTION
This fixes the issue. It's not the most elegant solution but my understanding is that currently it's the best way. See [here](https://github.com/actions/checkout/issues/766).

The problem comes from an update in git to solve a vulnerability. The checkout action has been fixed when the following commands are within the same step **and** not in a container. Since we are using a container to run the linter and the unittests, this is the current fix.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a `CHANGELOG.rst` entry
