### PR TITLE
Add python 3.10 support and remove 3.6

### DIFF
--- a/.ci_support/linux_64_python3.10_default.____cpython.yaml
+++ b/.ci_support/linux_64_python3.10_default.____cpython.yaml
@@ -1,5 +1,5 @@
 GLM_ARCHITECTURE:
-- 'skylake'
+- 'default'
 c_compiler:
 - gcc
 c_compiler_version:
@@ -9,8 +9,8 @@ cxx_compiler:
 cxx_compiler_version:
 - '9'
 numpy:
-- '1.17'
+- '1.21'
 python:
-- 3.6.* *_cpython
+- 3.10.* *_cpython
 target_platform:
 - linux-64

--- a/.ci_support/linux_64_python3.10_skylake.____cpython.yaml
+++ b/.ci_support/linux_64_python3.10_skylake.____cpython.yaml
@@ -1,5 +1,5 @@
 GLM_ARCHITECTURE:
-- 'default'
+- 'skylake'
 c_compiler:
 - gcc
 c_compiler_version:
@@ -9,8 +9,8 @@ cxx_compiler:
 cxx_compiler_version:
 - '9'
 numpy:
-- '1.17'
+- '1.21'
 python:
-- 3.6.* *_cpython
+- 3.10.* *_cpython
 target_platform:
 - linux-64

--- a/.ci_support/osx_64_python3.10_default.____cpython.yaml
+++ b/.ci_support/osx_64_python3.10_default.____cpython.yaml
@@ -1,0 +1,21 @@
+GLM_ARCHITECTURE:
+- 'default'
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+c_compiler:
+- clang
+c_compiler_version:
+- '11'
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '11'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+numpy:
+- '1.21'
+python:
+- 3.10.* *_cpython
+target_platform:
+- osx-64
+

--- a/.ci_support/osx_64_python3.10_skylake.____cpython.yaml
+++ b/.ci_support/osx_64_python3.10_skylake.____cpython.yaml
@@ -1,5 +1,5 @@
 GLM_ARCHITECTURE:
-- 'default'
+- 'skylake'
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
 c_compiler:
@@ -13,8 +13,9 @@ cxx_compiler_version:
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:
-- '1.17'
+- '1.21'
 python:
-- 3.6.* *_cpython
+- 3.10.* *_cpython
 target_platform:
 - osx-64
+

--- a/.ci_support/osx_arm64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.10.____cpython.yaml
@@ -1,7 +1,5 @@
-GLM_ARCHITECTURE:
-- 'skylake'
 MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
+- '11.0'
 c_compiler:
 - clang
 c_compiler_version:
@@ -11,10 +9,10 @@ cxx_compiler:
 cxx_compiler_version:
 - '11'
 macos_machine:
-- x86_64-apple-darwin13.4.0
+- arm64-apple-darwin20.0.0
 numpy:
-- '1.17'
+- '1.21'
 python:
-- 3.6.* *_cpython
+- 3.10.* *_cpython
 target_platform:
-- osx-64
+- osx-arm64

--- a/.ci_support/win_64_python3.10.____cpython.yaml
+++ b/.ci_support/win_64_python3.10.____cpython.yaml
@@ -5,8 +5,8 @@ c_compiler:
 cxx_compiler:
 - vs2017
 numpy:
-- '1.17'
+- '1.21'
 python:
-- 3.6.* *_cpython
+- 3.10.* *_cpython
 target_platform:
 - win-64

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -1,10 +1,6 @@
 name: Build and upload to PyPI
 
-on:
-  pull_request:
-  release:
-    types:
-      - published
+on: [push]
 
 jobs:
   build_wheels:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -1,6 +1,10 @@
 name: Build and upload to PyPI
 
-on: [push]
+on:
+  pull_request:
+  release:
+    types:
+      - published
 
 jobs:
   build_wheels:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        PYTHON_VERSION: ['3.6', '3.7', '3.8', '3.9']
+        PYTHON_VERSION: ['3.7', '3.8', '3.9', '3.10']
     steps:
      - name: Pull image
        run: docker pull condaforge/mambaforge:latest

--- a/.github/workflows/conda-build-linux-main.yml
+++ b/.github/workflows/conda-build-linux-main.yml
@@ -13,9 +13,10 @@ jobs:
       fail-fast: true
       matrix:
         CONDA_BUILD_YML:
-          - linux_64_python3.6_default.____cpython
+          - linux_64_python3.7_default.____cpython
           - linux_64_python3.8_skylake.____cpython
           - linux_64_python3.9_default.____cpython
+          - linux_64_python3.10_default.____cpython
     steps:
       - name: Pull image
         run: docker pull condaforge/mambaforge:latest

--- a/.github/workflows/conda-build-macos.yml
+++ b/.github/workflows/conda-build-macos.yml
@@ -15,10 +15,10 @@ jobs:
       fail-fast: false
       matrix:
         CONDA_BUILD_YML:
-          - osx_64_python3.6_default.____cpython
           - osx_64_python3.7_skylake.____cpython
           - osx_64_python3.8_default.____cpython
           - osx_arm64_python3.9.____cpython
+          - osx_arm64_python3.10.____cpython
     steps:
       - name: Checkout branch
         uses: actions/checkout@v3

--- a/.github/workflows/conda-build-win.yml
+++ b/.github/workflows/conda-build-win.yml
@@ -15,7 +15,8 @@ jobs:
       fail-fast: false
       matrix:
         CONDA_BUILD_YML:
-          - win_64_python3.6.____cpython
+          - win_64_python3.9.____cpython
+          - win_64_python3.10.____cpython
     steps:
       - name: Checkout branch
         uses: actions/checkout@v3

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,10 @@ Changelog
 Unreleased
 ----------
 
+**Other changes:**
+
+- Add Python 3.10 support.
+
 
 3.1.0 - 2022-03-07
 ------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ skip_glob = '\.eggs/*,\.git/*,\.venv/*,build/*,dist/*'
 default_section = 'THIRDPARTY'
 
 [tool.cibuildwheel]
-skip = ["cp310-*", "pp*", "*-musllinux_*"]
+skip = ["pp*", "*-musllinux_*"]
 test-requires = ["pytest", "pytest-xdist"]
 
 [tool.cibuildwheel.macos]

--- a/setup.py
+++ b/setup.py
@@ -129,10 +129,10 @@ setup(
     author_email="noreply@quantco.com",
     classifiers=[  # Optional
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
     package_dir={"": "src"},
     packages=find_packages(where="src"),


### PR DESCRIPTION
This should fix the failing CI (e.g. in #192). For some reasons we stopped supporting python 3.6 for glum a while ago, so this won't change much.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a `CHANGELOG.rst` entry
