### PR TITLE
Set GLM_ARCHITECTURE to default in cibuildwheel

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -10,8 +10,6 @@ jobs:
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    env:
-      GLM_ARCHITECTURE: default
     strategy:
       matrix:
         os: [ubuntu-20.04, macos-10.15, windows-2019]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ default_section = 'THIRDPARTY'
 [tool.cibuildwheel]
 skip = ["pp*", "*-musllinux_*"]
 test-requires = ["pytest", "pytest-xdist"]
+environment = "GLM_ARCHITECTURE='default'"
 
 [tool.cibuildwheel.macos]
 before-all = [


### PR DESCRIPTION
The environment variable that I set in #192 won't be funneled through to cibuildwheel (only use when building the source distribution). This PR should fix that.

See https://cibuildwheel.readthedocs.io/en/stable/options/#environment for how to set environment variables for cibuildwheel.