### PR TITLE
Pin xsimd to < 9

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -7,7 +7,7 @@ on:
     - '.github/workflows/daily.yml'
     - '.github/workflows/test.sh'
 
-# adding comment to trigger this run (revert back)
+# adding comment to trigger this run (revert back!)
 
 jobs:
   linux-daily-unittests:

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -7,6 +7,8 @@ on:
     - '.github/workflows/daily.yml'
     - '.github/workflows/test.sh'
 
+# adding comment to trigger this run (revert back)
+
 jobs:
   linux-daily-unittests:
     name: "Linux - daily unit tests - Python ${{ matrix.PYTHON_VERSION}} - ${{ matrix.NOTE }}"

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - numpy
     - pip
     - setuptools_scm
-    - xsimd
+    - xsimd < 9
   run:
     - python
     - {{ pin_compatible('numpy') }}

--- a/environment.yml
+++ b/environment.yml
@@ -24,7 +24,7 @@ dependencies:
   - make
   - mako
   - mkl-include
-  - xsimd
+  - xsimd < 9  # xsimd 9 does not play well with macos.
 
   # documentation dev
   - jupyterlab

--- a/src/tabmat/ext/dense_helpers-tmpl.cpp
+++ b/src/tabmat/ext/dense_helpers-tmpl.cpp
@@ -30,6 +30,12 @@
     #define XSIMD_BROADCAST set_simd
 #endif
 
+#if XSIMD_VERSION_MAJOR >= 9
+    #define XSIMD_REDUCE_ADD reduce_add
+#else
+    #define XSIMD_REDUCE_ADD hadd
+#endif
+
 namespace xs = xsimd;
 
 <%def name="middle_j(kparallel, IBLOCK, JBLOCK)">
@@ -85,7 +91,7 @@ namespace xs = xsimd;
         // horizontal sum of the simd blocks
         % for ir in range(IBLOCK):
             % for jr in range(JBLOCK):
-                F accum${ir}_${jr} = xs::hadd(accumsimd${ir}_${jr});
+                F accum${ir}_${jr} = xs::XSIMD_REDUCE_ADD(accumsimd${ir}_${jr});
             % endfor
         % endfor
 


### PR DESCRIPTION
xsimd v9.0 is the reason for the nightly failure (renamed `hadd` to `reduce_add`). I fixed the nightly failure but it turns out that xsimd v9.0 seems to be incompatible with macos, and all of our tests on macos are failing.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a `CHANGELOG.rst` entry
