### PR TITLE
Specify dtype in pd.get_dummies

### DIFF
--- a/src/tabmat/categorical_matrix.py
+++ b/src/tabmat/categorical_matrix.py
@@ -18,7 +18,7 @@ csr storage
     >>> import pandas as pd
 
     >>> arr = [1, 0, 1]
-    >>> dummies = pd.get_dummies(arr, dtype="int64")
+    >>> dummies = pd.get_dummies(arr, dtype="uint8")
     >>> csr = sparse.csr_matrix(dummies.values)
     >>> csr.data
     array([1, 1, 1], dtype=uint8)
@@ -46,7 +46,7 @@ However, we still do not need to store the data.
     >>> import pandas as pd
 
     >>> arr = [1, 0, 1]
-    >>> dummies = pd.get_dummies(arr, dtype="int64")
+    >>> dummies = pd.get_dummies(arr, dtype="uint8")
     >>> csc = sparse.csc_matrix(dummies.values)
     >>> csc.data
     array([1, 1, 1], dtype=uint8)

--- a/src/tabmat/categorical_matrix.py
+++ b/src/tabmat/categorical_matrix.py
@@ -18,7 +18,7 @@ csr storage
     >>> import pandas as pd
 
     >>> arr = [1, 0, 1]
-    >>> dummies = pd.get_dummies(arr)
+    >>> dummies = pd.get_dummies(arr, dtype="int64")
     >>> csr = sparse.csr_matrix(dummies.values)
     >>> csr.data
     array([1, 1, 1], dtype=uint8)
@@ -46,7 +46,7 @@ However, we still do not need to store the data.
     >>> import pandas as pd
 
     >>> arr = [1, 0, 1]
-    >>> dummies = pd.get_dummies(arr)
+    >>> dummies = pd.get_dummies(arr, dtype="int64")
     >>> csc = sparse.csc_matrix(dummies.values)
     >>> csc.data
     array([1, 1, 1], dtype=uint8)

--- a/tests/test_categorical_matrix.py
+++ b/tests/test_categorical_matrix.py
@@ -23,7 +23,7 @@ def test_recover_orig(cat_vec, vec_dtype, drop_first):
 @pytest.mark.parametrize("vec_dtype", [np.float64, np.float32, np.int64, np.int32])
 @pytest.mark.parametrize("drop_first", [True, False])
 def test_csr_matvec_categorical(cat_vec, vec_dtype, drop_first):
-    mat = pd.get_dummies(cat_vec, drop_first=drop_first, dtype="int64")
+    mat = pd.get_dummies(cat_vec, drop_first=drop_first, dtype="uint8")
     cat_mat = CategoricalMatrix(cat_vec, drop_first=drop_first)
     vec = np.random.choice(np.arange(4, dtype=vec_dtype), mat.shape[1])
     res = cat_mat.matvec(vec)
@@ -34,7 +34,7 @@ def test_csr_matvec_categorical(cat_vec, vec_dtype, drop_first):
 def test_tocsr(cat_vec, drop_first):
     cat_mat = CategoricalMatrix(cat_vec, drop_first=drop_first)
     res = cat_mat.tocsr().A
-    expected = pd.get_dummies(cat_vec, drop_first=drop_first, dtype="int64")
+    expected = pd.get_dummies(cat_vec, drop_first=drop_first, dtype="uint8")
     np.testing.assert_allclose(res, expected)
 
 
@@ -43,7 +43,7 @@ def test_transpose_matvec(cat_vec, drop_first):
     cat_mat = CategoricalMatrix(cat_vec, drop_first=drop_first)
     other = np.random.random(cat_mat.shape[0])
     res = cat_mat.transpose_matvec(other)
-    expected = pd.get_dummies(cat_vec, drop_first=drop_first, dtype="int64").T.dot(
+    expected = pd.get_dummies(cat_vec, drop_first=drop_first, dtype="uint8").T.dot(
         other
     )
     np.testing.assert_allclose(res, expected)
@@ -54,7 +54,7 @@ def test_multiply(cat_vec, drop_first):
     cat_mat = CategoricalMatrix(cat_vec, drop_first=drop_first)
     other = np.arange(len(cat_vec))[:, None]
     actual = cat_mat.multiply(other)
-    expected = pd.get_dummies(cat_vec, drop_first=drop_first, dtype="int64") * other
+    expected = pd.get_dummies(cat_vec, drop_first=drop_first, dtype="uint8") * other
     np.testing.assert_allclose(actual.A, expected)
 
 

--- a/tests/test_categorical_matrix.py
+++ b/tests/test_categorical_matrix.py
@@ -23,7 +23,7 @@ def test_recover_orig(cat_vec, vec_dtype, drop_first):
 @pytest.mark.parametrize("vec_dtype", [np.float64, np.float32, np.int64, np.int32])
 @pytest.mark.parametrize("drop_first", [True, False])
 def test_csr_matvec_categorical(cat_vec, vec_dtype, drop_first):
-    mat = pd.get_dummies(cat_vec, drop_first=drop_first)
+    mat = pd.get_dummies(cat_vec, drop_first=drop_first, dtype="int64")
     cat_mat = CategoricalMatrix(cat_vec, drop_first=drop_first)
     vec = np.random.choice(np.arange(4, dtype=vec_dtype), mat.shape[1])
     res = cat_mat.matvec(vec)
@@ -34,7 +34,7 @@ def test_csr_matvec_categorical(cat_vec, vec_dtype, drop_first):
 def test_tocsr(cat_vec, drop_first):
     cat_mat = CategoricalMatrix(cat_vec, drop_first=drop_first)
     res = cat_mat.tocsr().A
-    expected = pd.get_dummies(cat_vec, drop_first=drop_first)
+    expected = pd.get_dummies(cat_vec, drop_first=drop_first, dtype="int64")
     np.testing.assert_allclose(res, expected)
 
 
@@ -43,7 +43,9 @@ def test_transpose_matvec(cat_vec, drop_first):
     cat_mat = CategoricalMatrix(cat_vec, drop_first=drop_first)
     other = np.random.random(cat_mat.shape[0])
     res = cat_mat.transpose_matvec(other)
-    expected = pd.get_dummies(cat_vec, drop_first=drop_first).T.dot(other)
+    expected = pd.get_dummies(cat_vec, drop_first=drop_first, dtype="int64").T.dot(
+        other
+    )
     np.testing.assert_allclose(res, expected)
 
 
@@ -52,7 +54,7 @@ def test_multiply(cat_vec, drop_first):
     cat_mat = CategoricalMatrix(cat_vec, drop_first=drop_first)
     other = np.arange(len(cat_vec))[:, None]
     actual = cat_mat.multiply(other)
-    expected = pd.get_dummies(cat_vec, drop_first=drop_first) * other
+    expected = pd.get_dummies(cat_vec, drop_first=drop_first, dtype="int64") * other
     np.testing.assert_allclose(actual.A, expected)
 
 


### PR DESCRIPTION
Closes #200.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* ~[ ] Added a `CHANGELOG.rst` entry~

As of pandas 1.6, `pd.get_dummies` will return booleans. This fixes the tests and the docstrings. No user facing code was modified.

CI run against dailies: https://github.com/Quantco/tabmat/actions/runs/3422260962