### PR TITLE
Skip wheels for win32

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,12 @@ skip_glob = '\.eggs/*,\.git/*,\.venv/*,build/*,dist/*'
 default_section = 'THIRDPARTY'
 
 [tool.cibuildwheel]
-skip = ["pp*", "*-musllinux_*"]
+skip = [
+  "*-win32",
+  "*-manylinux_i686",
+  "pp*", 
+  "*-musllinux_*"
+]
 test-requires = ["pytest", "pytest-xdist"]
 # note: ARCHS_LINUX defined in build_wheels.yml file.
 


### PR DESCRIPTION
And for `manylinux_i686` as well. I'm aligning this with `glum`, see [here](https://github.com/Quantco/glum/blob/f09d09e712861fa5e499da59b92c858509789c01/pyproject.toml#LL31-L37C2).

Or is there a good reason to have `tabmat` wheels for architectures that `glum` isn't supporting?

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a `CHANGELOG.rst` entry
