### PR TITLE
Use 64bit int for indexing in cross sandwich product

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@
 Changelog
 =========
 
+3.1.7 - 2022-03-28
+------------------
+
+**Bug fix:**
+
+- We fixed a bug in the cross sandwich product, which would previously segfault for very large matrices.
+
+
 3.1.6 - 2022-03-27
 ------------------
 

--- a/src/tabmat/ext/sparse_helpers-tmpl.cpp
+++ b/src/tabmat/ext/sparse_helpers-tmpl.cpp
@@ -6,6 +6,12 @@
 
 #include "alloc.h"
 
+#ifdef _WIN32
+    #define SIZE_T long long
+#else
+    #define SIZE_T size_t
+#endif
+
 #if XSIMD_VERSION_MAJOR >= 8
     #define XSIMD_BROADCAST broadcast
 #else
@@ -68,9 +74,9 @@ void _csr_dense${order}_sandwich(
 
                 F* R = &Rglobal.get()[omp_get_thread_num()*kblock*jblock];
                 for (Int Ck = Ckk; Ck < Ckmax; Ck++) {
-                    Int k = rows[Ck];
+                    SIZE_T k = rows[Ck];
                     for (Int Cj = Cjj; Cj < Cjmax; Cj++) {
-                        Int j = B_cols[Cj];
+                        SIZE_T j = B_cols[Cj];
                         %if order == 'C':
                             F Bv = B[k * r + j];
                         % else:


### PR DESCRIPTION
This fixes #239.

Please double check that I haven't missed more cases so that we tackle any final overflow issues in this PR. 

Checklist
* [x] Added a `CHANGELOG.rst` entry
