### PR TITLE
Use language_level=3 for Cython

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -154,6 +154,10 @@ setup(
     package_dir={"": "src"},
     packages=find_packages(where="src"),
     install_requires=["numpy", "pandas", "scipy"],
-    ext_modules=cythonize(ext_modules, annotate=False),
+    ext_modules=cythonize(
+        ext_modules,
+        annotate=False,
+        compiler_directives={'language_level': "3"},
+    ),
     zip_safe=False,
 )


### PR DESCRIPTION
Even though this compiles without any problem, this specifies that the Python 3 syntax is to be used for Cython compilation.

This allows removing some warnings.

---

For now, Cython directives are sitting at the head of Cython sources. Moreover, some functions are documented but do not need to be because of the directives.

Hence, would it make sense to add those directives in the call to `cythonize` here instead?
