### PR TITLE
Add a message to the Exception in dense_sandwich

### DIFF
--- a/src/tabmat/ext/dense.pyx
+++ b/src/tabmat/ext/dense.pyx
@@ -38,7 +38,7 @@ def dense_sandwich(np.ndarray X, floating[:] d, int[:] rows, int[:] cols, int th
     elif X.flags["F_CONTIGUOUS"]:
         _denseF_sandwich(rowsp, colsp, Xp, dp, outp, in_n, out_m, m, n, thresh1d, kratio, innerblock)
     else:
-        raise Exception()
+        raise Exception("The matrix X is not contiguous.")
     return out
 
 


### PR DESCRIPTION
Fixes #208.

This is a simple fix.

I think that there are several alternatives if the provided array isn't contiguous:
 - make a copy of this array
 - raise an Exception as soon as possible, i.e. at the creation of:
   - `DenseMatrix`
   - `SparseMatrix`
   - `SplitMatrix`
   
Which one do you think is more appropriate?