### PR TITLE
Matvec dimensions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,8 @@ Unreleased
 **Other changes:**
 
 - The C++ types have been refactored. Loop indices are now using the ``Py_ssize_t`` type. Integers now have a templated type as well.
+- The documentation for `matvec` and `matvec_transpose` has been updated to reflect actual behavior
+- Checks for dimension mismatch in `matvec` and `matvec_transpose` arguments have been added
 
 3.1.7 - 2022-03-28
 ------------------

--- a/src/tabmat/categorical_matrix.py
+++ b/src/tabmat/categorical_matrix.py
@@ -350,7 +350,7 @@ class CategoricalMatrix(MatrixBase):
     ) -> np.ndarray:
         """
 
-        Perform: self[rows, cols].T @ vec.
+        Perform: self[rows, cols].T @ vec[rows].
 
         ::
 

--- a/src/tabmat/categorical_matrix.py
+++ b/src/tabmat/categorical_matrix.py
@@ -181,6 +181,7 @@ from .ext.split import sandwich_cat_cat, sandwich_cat_dense
 from .matrix_base import MatrixBase
 from .sparse_matrix import SparseMatrix
 from .util import (
+    check_matvec_dimensions,
     check_matvec_out_shape,
     check_transpose_matvec_out_shape,
     set_up_rows_or_cols,
@@ -282,11 +283,7 @@ class CategoricalMatrix(MatrixBase):
             raise NotImplementedError(
                 """CategoricalMatrix.matvec is only implemented for 1d arrays."""
             )
-        if other.shape[0] != self.shape[1]:
-            raise ValueError(
-                f"""Needed other to have first dimension {self.shape[1]},
-                but it has shape {other.shape}"""
-            )
+        check_matvec_dimensions(self, other, transpose=False)
 
         if cols is not None:
             if len(cols) == self.shape[1]:
@@ -380,6 +377,7 @@ class CategoricalMatrix(MatrixBase):
         # TODO: write a function that doesn't reference the data
         # TODO: this should look more like the cat_cat_sandwich
         vec = np.asarray(vec)
+        check_matvec_dimensions(self, vec, transpose=True)
         if vec.ndim > 1:
             raise NotImplementedError(
                 "CategoricalMatrix.transpose_matvec is only implemented for 1d arrays."

--- a/src/tabmat/dense_matrix.py
+++ b/src/tabmat/dense_matrix.py
@@ -10,6 +10,7 @@ from .ext.dense import (
 )
 from .matrix_base import MatrixBase
 from .util import (
+    check_matvec_dimensions,
     check_matvec_out_shape,
     check_transpose_matvec_out_shape,
     setup_restrictions,
@@ -102,8 +103,9 @@ class DenseMatrix(np.ndarray, MatrixBase):
         # TODO: related to above, it could be nice to have a version that only
         # filters rows and a version that only filters columns. How do we do
         # this without an explosion of code?
-        X = self.T if transpose else self
         vec = np.asarray(vec)
+        check_matvec_dimensions(self, vec, transpose=transpose)
+        X = self.T if transpose else self
 
         # NOTE: We assume that rows and cols are unique
         unrestricted_rows = rows is None or len(rows) == self.shape[0]

--- a/src/tabmat/dense_matrix.py
+++ b/src/tabmat/dense_matrix.py
@@ -142,7 +142,7 @@ class DenseMatrix(np.ndarray, MatrixBase):
         cols: np.ndarray = None,
         out: np.ndarray = None,
     ) -> np.ndarray:
-        """Perform: self[rows, cols].T @ vec."""
+        """Perform: self[rows, cols].T @ vec[rows]."""
         check_transpose_matvec_out_shape(self, out)
         return self._matvec_helper(vec, rows, cols, out, True)
 
@@ -152,7 +152,7 @@ class DenseMatrix(np.ndarray, MatrixBase):
         cols: np.ndarray = None,
         out: np.ndarray = None,
     ) -> np.ndarray:
-        """Perform self[:, cols] @ other."""
+        """Perform self[:, cols] @ other[cols]."""
         check_matvec_out_shape(self, out)
         return self._matvec_helper(vec, None, cols, out, False)
 

--- a/src/tabmat/matrix_base.py
+++ b/src/tabmat/matrix_base.py
@@ -14,7 +14,7 @@ class MatrixBase(ABC):
     @abstractmethod
     def matvec(self, other, cols: np.ndarray = None, out: np.ndarray = None):
         """
-        Perform: self[:, cols] @ other, so result[i] = sum_j self[i, j] other[j].
+        Perform: self[:, cols] @ other[cols], so result[i] = sum_j self[i, j] other[j].
 
         The 'cols' parameter allows restricting to a subset of the matrix without making
         a copy. If provided:
@@ -37,7 +37,7 @@ class MatrixBase(ABC):
         out: np.ndarray = None,
     ) -> np.ndarray:
         """
-        Perform: self[rows, cols].T @ vec, so result[i] = sum_j self[j, i] vec[j].
+        Perform: self[rows, cols].T @ vec[rows], so result[i] = sum_j self[j, i] vec[j].
 
         The rows and cols parameters allow restricting to a subset of the
         matrix without making a copy.

--- a/src/tabmat/sparse_matrix.py
+++ b/src/tabmat/sparse_matrix.py
@@ -175,7 +175,7 @@ class SparseMatrix(sps.csc_matrix, MatrixBase):
         cols: np.ndarray = None,
         out: np.ndarray = None,
     ) -> np.ndarray:
-        """Perform: self[rows, cols].T @ vec."""
+        """Perform: self[rows, cols].T @ vec[rows]."""
         check_transpose_matvec_out_shape(self, out)
         return self._matvec_helper(vec, rows, cols, out, True)
 

--- a/src/tabmat/sparse_matrix.py
+++ b/src/tabmat/sparse_matrix.py
@@ -14,6 +14,7 @@ from .ext.sparse import (
 )
 from .matrix_base import MatrixBase
 from .util import (
+    check_matvec_dimensions,
     check_matvec_out_shape,
     check_transpose_matvec_out_shape,
     set_up_rows_or_cols,
@@ -120,13 +121,8 @@ class SparseMatrix(sps.csc_matrix, MatrixBase):
         out: Optional[np.ndarray],
         transpose: bool,
     ):
-        match_dim = 0 if transpose else 1
         vec = np.asarray(vec)
-        if self.shape[match_dim] != vec.shape[0]:
-            raise ValueError(
-                f"shapes {self.shape} and {vec.shape} not aligned:"
-                f"{self.shape[match_dim]} (dim {match_dim}) != {vec.shape[0]} (dim 0)"
-            )
+        check_matvec_dimensions(self, vec, transpose)
 
         unrestricted_rows = rows is None or len(rows) == self.shape[0]
         unrestricted_cols = cols is None or len(cols) == self.shape[1]

--- a/src/tabmat/split_matrix.py
+++ b/src/tabmat/split_matrix.py
@@ -322,7 +322,7 @@ class SplitMatrix(MatrixBase):
     def matvec(
         self, v: np.ndarray, cols: np.ndarray = None, out: np.ndarray = None
     ) -> np.ndarray:
-        """Perform self[:, cols] @ other."""
+        """Perform self[:, cols] @ other[cols]."""
         assert not isinstance(v, sps.spmatrix)
         check_matvec_out_shape(self, out)
 
@@ -371,7 +371,7 @@ class SplitMatrix(MatrixBase):
         out: np.ndarray = None,
     ) -> np.ndarray:
         """
-        Perform: self[rows, cols].T @ vec.
+        Perform: self[rows, cols].T @ vec[rows].
 
         ::
 

--- a/src/tabmat/standardized_mat.py
+++ b/src/tabmat/standardized_mat.py
@@ -7,6 +7,7 @@ from .dense_matrix import DenseMatrix
 from .matrix_base import MatrixBase
 from .sparse_matrix import SparseMatrix
 from .util import (
+    check_matvec_dimensions,
     check_transpose_matvec_out_shape,
     set_up_rows_or_cols,
     setup_restrictions,
@@ -70,7 +71,7 @@ class StandardizedMatrix:
         out: np.ndarray = None,
     ) -> np.ndarray:
         """
-        Perform self[:, cols] @ other.
+        Perform self[:, cols] @ other[cols].
 
         This function returns a dense output, so it is best geared for the
         matrix-vector case.
@@ -78,6 +79,7 @@ class StandardizedMatrix:
         cols = set_up_rows_or_cols(cols, self.shape[1])
 
         other_mat = np.asarray(other_mat)
+        check_matvec_dimensions(self, other_mat, transpose=False)
         mult_other = other_mat
         if self.mult is not None:
             mult = self.mult
@@ -172,7 +174,7 @@ class StandardizedMatrix:
         out: np.ndarray = None,
     ) -> np.ndarray:
         """
-        Perform: self[rows, cols].T @ vec.
+        Perform: self[rows, cols].T @ vec[rows].
 
         Let self.shape = (N, K) and other.shape = (M, N).
         Let shift_mat = outer(ones(N), shift)
@@ -194,6 +196,7 @@ class StandardizedMatrix:
         """
         check_transpose_matvec_out_shape(self, out)
         other = np.asarray(other)
+        check_matvec_dimensions(self, other, transpose=True)
         res = self.mat.transpose_matvec(other, rows, cols)
 
         rows, cols = setup_restrictions(self.shape, rows, cols)

--- a/src/tabmat/util.py
+++ b/src/tabmat/util.py
@@ -40,3 +40,13 @@ def check_transpose_matvec_out_shape(mat, out: Optional[np.ndarray]) -> None:
 def check_matvec_out_shape(mat, out: Optional[np.ndarray]) -> None:
     """Assert that the first dimension of the matvec output is correct."""
     _check_out_shape(out, mat.shape[0])
+
+
+def check_matvec_dimensions(mat, vec: np.ndarray, transpose: bool) -> None:
+    """Assert that the dimensions for the matvec operation are compatible."""
+    match_dim = 0 if transpose else 1
+    if mat.shape[match_dim] != vec.shape[0]:
+        raise ValueError(
+            f"shapes {mat.shape} and {vec.shape} not aligned: "
+            f"{mat.shape[match_dim]} (dim {match_dim}) != {vec.shape[0]} (dim 0)"
+        )

--- a/tests/test_matrices.py
+++ b/tests/test_matrices.py
@@ -166,6 +166,29 @@ def test_transpose_matvec_out_parameter(mat, cols, rows):
 
 
 @pytest.mark.parametrize("mat", get_matrices())
+@pytest.mark.parametrize("cols", [None, [], [1], np.array([0, 1])])
+@pytest.mark.parametrize("rows", [None, [], [1], np.array([0, 2])])
+def test_matvec_dimension_mismatch_raises(mat, rows, cols):
+    too_short = np.ones(mat.shape[1] - 1, dtype=mat.dtype)
+    just_right = np.ones(mat.shape[1], dtype=mat.dtype)
+    too_long = np.ones(mat.shape[1] + 1, dtype=mat.dtype)
+    mat.matvec(just_right, cols=cols)
+    with pytest.raises(ValueError):
+        mat.matvec(too_short, cols=cols)
+    with pytest.raises(ValueError):
+        mat.matvec(too_long, cols=cols)
+
+    too_short_transpose = np.ones(mat.shape[0] - 1, dtype=mat.dtype)
+    just_right_transpose = np.ones(mat.shape[0], dtype=mat.dtype)
+    too_long_transpose = np.ones(mat.shape[0] + 1, dtype=mat.dtype)
+    mat.transpose_matvec(just_right_transpose, rows=rows, cols=cols)
+    with pytest.raises(ValueError):
+        mat.transpose_matvec(too_short_transpose, rows=rows, cols=cols)
+    with pytest.raises(ValueError):
+        mat.transpose_matvec(too_long_transpose, rows=rows, cols=cols)
+
+
+@pytest.mark.parametrize("mat", get_matrices())
 @pytest.mark.parametrize("i", [1, -2])
 def test_getcol(mat: Union[tm.MatrixBase, tm.StandardizedMatrix], i):
     col = mat.getcol(i)


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a `CHANGELOG.rst` entry

Update the documentation to reflect the actual behavior of `matvec` and `matvec_transpose`: `X.matvec(b, cols=cols) == X[:, cols] @ b[cols]`. Also, checks have been added to detect dimension mismatch and raise a `ValueError` in the case of all `MatrixBase` subclasses.

"Fixes" #256 