### PR TITLE
Fix `getcol` not respecting `drop_first`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,10 @@ Changelog
 3.1.9 - 2023-06-16
 -------------------
 
+**Bug fix:**
+
+- Fix `getcol` not respecting the `drop_first` attribute of `CategoricalMatrix`.
+
 **Other changes:**
 
 - Support building on architectures that are unsupported by xsimd.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,12 +7,15 @@
 Changelog
 =========
 
-3.1.9 - 2023-06-16
+3.1.10 - 2023-XX-XX
 -------------------
 
 **Bug fix:**
 
 - Fix `getcol` not respecting the `drop_first` attribute of `CategoricalMatrix`.
+
+3.1.9 - 2023-06-16
+------------------
 
 **Other changes:**
 

--- a/src/tabmat/categorical_matrix.py
+++ b/src/tabmat/categorical_matrix.py
@@ -465,6 +465,10 @@ class CategoricalMatrix(MatrixBase):
     def getcol(self, i: int) -> sps.csc_matrix:
         """Return matrix column at specified index."""
         i %= self.shape[1]  # wrap-around indexing
+
+        if self.drop_first:
+            i += 1
+
         col_i = sps.csc_matrix((self.indices == i).astype(int)[:, None])
         return col_i
 

--- a/tests/test_matrices.py
+++ b/tests/test_matrices.py
@@ -45,6 +45,11 @@ def categorical_matrix():
     return tm.CategoricalMatrix(vec)
 
 
+def categorical_matrix_drop_first():
+    vec = [0, 1, 2]
+    return tm.CategoricalMatrix(vec, drop_first=True)
+
+
 def get_unscaled_matrices() -> (
     List[Union[tm.DenseMatrix, tm.SparseMatrix, tm.CategoricalMatrix]]
 ):
@@ -55,6 +60,7 @@ def get_unscaled_matrices() -> (
         sparse_matrix(),
         sparse_matrix_64(),
         categorical_matrix(),
+        categorical_matrix_drop_first(),
     ]
 
 
@@ -201,8 +207,10 @@ def test_getcol(mat: Union[tm.MatrixBase, tm.StandardizedMatrix], i):
 @pytest.mark.parametrize("mat", get_all_matrix_base_subclass_mats())
 def test_to_array_matrix_base(mat: tm.MatrixBase):
     assert isinstance(mat.A, np.ndarray)
-    if isinstance(mat, tm.CategoricalMatrix):
+    if isinstance(mat, tm.CategoricalMatrix) and not mat.drop_first:
         expected = np.array([[0, 1], [1, 0], [0, 1]])
+    elif isinstance(mat, tm.CategoricalMatrix) and mat.drop_first:
+        expected = np.array([[0, 0], [1, 0], [0, 1]])
     elif isinstance(mat, tm.SplitMatrix):
         expected = np.hstack([elt.A for elt in mat.matrices])
     else:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a `CHANGELOG.rst` entry

This PR fixes #265 and adds tests for categorical matrices with `drop_first=True`.