### PR TITLE
Improve the performance of `from_pandas` in the case of low-cardinality categoricals

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,13 @@
 Changelog
 =========
 
+3.1.11 - 2023-XX-XX
+-------------------
+
+**Other changes:**
+
+- Improve the performance of ``from_pandas`` in the case of low-cardinality categorical variables.
+
 3.1.10 - 2023-06-23
 -------------------
 

--- a/src/tabmat/constructor.py
+++ b/src/tabmat/constructor.py
@@ -72,6 +72,7 @@ def from_pandas(
         if object_as_cat and coldata.dtype == object:
             coldata = coldata.astype("category")
         if isinstance(coldata.dtype, pd.CategoricalDtype):
+            cat = CategoricalMatrix(coldata, drop_first=drop_first, dtype=dtype)
             if len(coldata.cat.categories) < cat_threshold:
                 (
                     X_dense_F,
@@ -79,15 +80,7 @@ def from_pandas(
                     dense_indices,
                     sparse_indices,
                 ) = _split_sparse_and_dense_parts(
-                    pd.get_dummies(
-                        coldata,
-                        prefix=colname,
-                        sparse=True,
-                        drop_first=drop_first,
-                        dtype=np.float64,
-                    )
-                    .sparse.to_coo()
-                    .tocsc(),
+                    sps.csc_matrix(cat.tocsr(), dtype=dtype),
                     threshold=sparse_threshold,
                 )
                 matrices.append(X_dense_F)
@@ -103,7 +96,6 @@ def from_pandas(
                     indices.append(sparse_indices)
 
             else:
-                cat = CategoricalMatrix(coldata, drop_first=drop_first, dtype=dtype)
                 matrices.append(cat)
                 is_cat.append(True)
                 if cat_position == "expand":


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a `CHANGELOG.rst` entry

When encountering low-cardinality (i.e. `< cat_threshold`) categorical variables, `from_pandas` uses the `pandas.get_dummies` to create a dummy encoding. It turns out that that function is quite slow, and `tabmat` already has a much more performant way of achieving the same result: `CategoricalMatrix.tocsr()`. This PR switches the former with the latter and significantly improves runtime.

## Microbenchmark

```python
import timeit
import numpy as np
import pandas as pd
import tabmat as tm

df = pd.DataFrame({
    "cat": pd.Categorical(np.random.choice(["a", "b", "c"], size=1_000_000)),
})

fun = lambda: tm.from_pandas(df)
timeit.timeit(fun, number=10) / 10 * 1000
```

The implementation on branch `main` takes roughly **140 ms** on my laptop, while the one proposed in this PR finishes in around **12 ms**.