### PR TITLE
Add column name metadata to `tabmat` matrices

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,10 @@ Changelog
 Unreleased
 ----------
 
+**New features:**
+
+- Add column name and term name metadata to ``MatrixBase`` objects. These are automatically populated when initializing a ``MatrixBase`` from a ``pandas.DataFrame``. In addition, they can be accessed and modified via the ``column_names`` and ``term_names`` properties.
+
 **Other changes:**
 
 - Improve the performance of ``from_pandas`` in the case of low-cardinality categorical variables.

--- a/src/tabmat/categorical_matrix.py
+++ b/src/tabmat/categorical_matrix.py
@@ -250,6 +250,9 @@ class CategoricalMatrix(MatrixBase):
         cat_vec: Union[List, np.ndarray, pd.Categorical],
         drop_first: bool = False,
         dtype: np.dtype = np.float64,
+        column_name: Optional[str] = None,
+        term_name: Optional[str] = None,
+        column_name_format: str = "{name}[{category}]",
     ):
         if pd.isnull(cat_vec).any():
             raise ValueError("Categorical data can't have missing values.")
@@ -264,9 +267,13 @@ class CategoricalMatrix(MatrixBase):
         self.indices = self.cat.codes.astype(np.int32)
         self.x_csc: Optional[Tuple[Optional[np.ndarray], np.ndarray, np.ndarray]] = None
         self.dtype = np.dtype(dtype)
-        self._colname = None
-        self._term = None
-        self._colname_format = "{name}[{category}]"
+
+        self._colname = column_name
+        if term_name is None:
+            self._term = self._colname
+        else:
+            self._term = term_name
+        self._colname_format = column_name_format
 
     __array_ufunc__ = None
 

--- a/src/tabmat/categorical_matrix.py
+++ b/src/tabmat/categorical_matrix.py
@@ -477,10 +477,16 @@ class CategoricalMatrix(MatrixBase):
         i %= self.shape[1]  # wrap-around indexing
 
         if self.drop_first:
-            i += 1
+            i_corr = i + 1
+        else:
+            i_corr = i
 
-        col_i = sps.csc_matrix((self.indices == i).astype(int)[:, None])
-        return SparseMatrix(col_i)
+        col_i = sps.csc_matrix((self.indices == i_corr).astype(int)[:, None])
+        return SparseMatrix(
+            col_i,
+            column_names=[self.column_names[i]],
+            term_names=[self.term_names[i]],
+        )
 
     def tocsr(self) -> sps.csr_matrix:
         """Return scipy csr representation of matrix."""
@@ -657,7 +663,9 @@ class CategoricalMatrix(MatrixBase):
                     np.arange(self.shape[0] + 1, dtype=int),
                 ),
                 shape=self.shape,
-            )
+            ),
+            column_names=self.column_names,
+            term_names=self.term_names,
         )
 
     def __repr__(self):

--- a/src/tabmat/categorical_matrix.py
+++ b/src/tabmat/categorical_matrix.py
@@ -745,7 +745,11 @@ class CategoricalMatrix(MatrixBase):
                         name="__CAPTURE__", category=cat
                     )
                     pattern = re.escape(partial_name).replace("__CAPTURE__", "(.*)")
-                    if (name is not None) and (match := re.search(pattern, name)):
+                    if name is not None:
+                        match = re.search(pattern, name)
+                    else:
+                        match = None
+                    if match is not None:
                         base_names.append(match.group(1))
                     else:
                         base_names.append(name)

--- a/src/tabmat/categorical_matrix.py
+++ b/src/tabmat/categorical_matrix.py
@@ -718,3 +718,32 @@ class CategoricalMatrix(MatrixBase):
             ]
         else:
             return [name] * (len(self.cat.categories) - self.drop_first)
+
+    def set_names(self, names: Union[str, List[Optional[str]]], type: str = "column"):
+        """Set column names.
+
+        Parameters
+        ----------
+        names: List[Optional[str]]
+            Names to set.
+        type: str {'column'|'term'}
+            Whether to set column names or term names. The main difference is that
+            a categorical submatrix is counted as a single term, whereas it is
+            counted as multiple columns. Furthermore, matrices created from formulas
+            have a difference between a column and term (c.f. ``formulaic`` docs).
+        """
+        if isinstance(names, str):
+            names = [names]
+
+        if len(names) == self.shape[1] and all(name == names[0] for name in names):
+            names = [names[0]]
+
+        if len(names) != 1:
+            raise ValueError("A categorical matrix has only one name")
+
+        if type == "column":
+            self._colname = names[0]
+        elif type == "term":
+            self._term = names[0]
+        else:
+            raise ValueError(f"Type must be 'column' or 'term', got {type}")

--- a/src/tabmat/categorical_matrix.py
+++ b/src/tabmat/categorical_matrix.py
@@ -669,9 +669,9 @@ class CategoricalMatrix(MatrixBase):
     def get_names(
         self,
         type: str = "column",
-        missing_prefix: str = "_col_",
+        missing_prefix: Optional[str] = None,
         indices: Optional[List[int]] = None,
-    ) -> List[str]:
+    ) -> List[Optional[str]]:
         """Get column names.
 
         For columns that do not have a name, a default name is created using the
@@ -685,15 +685,16 @@ class CategoricalMatrix(MatrixBase):
             a categorical submatrix is counted as a single term, whereas it is
             counted as multiple columns. Furthermore, matrices created from formulas
             have a difference between a column and term (c.f. ``formulaic`` docs).
-        missing_prefix
-            Prefix to use for columns that do not have a name.
+        missing_prefix: Optional[str], default None
+            Prefix to use for columns that do not have a name. If None, then no
+            default name is created.
         indices
             The indices used for columns that do not have a name. If ``None``,
             then the indices are ``list(range(self.shape[1]))``.
 
         Returns
         -------
-        list of str
+        List[Optional[str]]
             Column names.
         """
         if type == "column":
@@ -705,7 +706,9 @@ class CategoricalMatrix(MatrixBase):
 
         if indices is None:
             indices = list(range(len(self.cat.categories) - self.drop_first))
-        if name is None:
+        if name is None and missing_prefix is None:
+            return [None] * (len(self.cat.categories) - self.drop_first)
+        elif name is None:
             name = f"{missing_prefix}{indices[0]}-{indices[-1]}"
 
         if type == "column":

--- a/src/tabmat/categorical_matrix.py
+++ b/src/tabmat/categorical_matrix.py
@@ -667,7 +667,7 @@ class CategoricalMatrix(MatrixBase):
         return str(self.cat)
 
     def get_column_names(
-        self, missing_prefix: str = "_col_", start_index: int = 0
+        self, missing_prefix: str = "_col_", indices: Optional[List[int]] = None
     ) -> List[str]:
         """Get column names.
 
@@ -679,16 +679,19 @@ class CategoricalMatrix(MatrixBase):
         ----------
         missing_prefix
             Prefix to use for columns that do not have a name.
-        start_index
-            Index to start from when creating default names.
+        indices
+            The indices used for columns that do not have a name. If ``None``,
+            then the indices are ``list(range(self.shape[1]))``.
 
         Returns
         -------
         list of str
             Column names.
         """
+        if indices is None:
+            indices = list(range(len(self.cat.categories) - self.drop_first))
         if self._colname is None:
-            colname = f"{missing_prefix}{start_index}"
+            colname = f"{missing_prefix}{indices[0]}-{indices[-1]}"
         else:
             colname = self._colname
         return [
@@ -697,7 +700,7 @@ class CategoricalMatrix(MatrixBase):
         ]
 
     def get_term_names(
-        self, missing_prefix: str = "_col_", start_index: int = 0
+        self, missing_prefix: str = "_col_", indices: Optional[List[int]] = None
     ) -> List[str]:
         """Get term names.
 
@@ -712,16 +715,19 @@ class CategoricalMatrix(MatrixBase):
         ----------
         missing_prefix
             Prefix to use for terms that do not have a name.
-        start_index
-            Index to start from when creating default names.
+        indices
+            The indices used for columns that do not have a name. If ``None``,
+            then the indices are ``list(range(self.shape[1]))``.
 
         Returns
         -------
         list of str
             Term names.
         """
+        if indices is None:
+            indices = list(range(len(self.cat.categories) - self.drop_first))
         if self._term is None:
-            term = f"{missing_prefix}{start_index}"
+            term = f"{missing_prefix}{indices[0]}-{indices[-1]}"
         else:
             term = self._term
         return [term] * (len(self.cat.categories) - self.drop_first)

--- a/src/tabmat/constructor.py
+++ b/src/tabmat/constructor.py
@@ -227,9 +227,5 @@ def from_csc(mat: sps.csc_matrix, threshold=0.1, column_names=None, term_names=N
     The ``threshold`` parameter specifies the density below which a column is
     treated as sparse.
     """
-    if column_names is None:
-        column_names = [None] * mat.shape[1]
-    if term_names is None:
-        term_names = column_names
     dense, sparse, dense_idx, sparse_idx = _split_sparse_and_dense_parts(mat, threshold)
     return SplitMatrix([dense, sparse], [dense_idx, sparse_idx])

--- a/src/tabmat/constructor.py
+++ b/src/tabmat/constructor.py
@@ -90,8 +90,8 @@ def from_pandas(
                 ) = _split_sparse_and_dense_parts(
                     sps.csc_matrix(cat.tocsr(), dtype=dtype),
                     threshold=sparse_threshold,
-                    column_names=cat.get_column_names(),
-                    term_names=cat.get_term_names(),
+                    column_names=cat.get_names("columns"),
+                    term_names=cat.get_names("terms"),
                 )
                 matrices.append(X_dense_F)
                 is_cat.append(True)

--- a/src/tabmat/constructor.py
+++ b/src/tabmat/constructor.py
@@ -90,8 +90,8 @@ def from_pandas(
                 ) = _split_sparse_and_dense_parts(
                     sps.csc_matrix(cat.tocsr(), dtype=dtype),
                     threshold=sparse_threshold,
-                    column_names=cat.get_names("columns"),
-                    term_names=cat.get_names("terms"),
+                    column_names=cat.get_names("column"),
+                    term_names=cat.get_names("term"),
                 )
                 matrices.append(X_dense_F)
                 is_cat.append(True)

--- a/src/tabmat/dense_matrix.py
+++ b/src/tabmat/dense_matrix.py
@@ -58,7 +58,7 @@ class DenseMatrix(MatrixBase):
                 raise ValueError(f"Expected {width} term names, got {len(term_names)}")
             self._terms = term_names
         else:
-            self._terms = obj._colnames
+            self._terms = self._colnames
 
     def __getitem__(self, key):
         if not isinstance(key, tuple):
@@ -116,7 +116,7 @@ class DenseMatrix(MatrixBase):
 
     def __getitem__(self, key):
         """Return a subset of the matrix."""
-        result = super().__getitem__(key)
+        result = type(self)(self._array.__getitem__(key))
         if isinstance(key, tuple) and len(key) == 2:
             result._colnames = list(np.array(self._colnames)[key[1]])
             result._terms = list(np.array(self._terms)[key[1]])
@@ -284,7 +284,7 @@ class DenseMatrix(MatrixBase):
             raise ValueError(f"Type must be 'column' or 'term', got {type}")
 
         if indices is None:
-            indices = list(range(self.shape[1]))
+            indices = list(range(len(self._colnames)))
 
         if missing_prefix is not None:
             default_names = np.array([f"{missing_prefix}{i}" for i in indices])

--- a/src/tabmat/dense_matrix.py
+++ b/src/tabmat/dense_matrix.py
@@ -291,3 +291,29 @@ class DenseMatrix(MatrixBase):
             names[names == None] = default_names[names == None]  # noqa: E711
 
         return list(names)
+
+    def set_names(self, names: Union[str, List[Optional[str]]], type: str = "column"):
+        """Set column names.
+
+        Parameters
+        ----------
+        names: List[Optional[str]]
+            Names to set.
+        type: str {'column'|'term'}
+            Whether to set column names or term names. The main difference is that
+            a categorical submatrix is counted as a single term, whereas it is
+            counted as multiple columns. Furthermore, matrices created from formulas
+            have a difference between a column and term (c.f. ``formulaic`` docs).
+        """
+        if isinstance(names, str):
+            names = [names]
+
+        if len(names) != self.shape[1]:
+            raise ValueError(f"Length of names must be {self.shape[1]}")
+
+        if type == "column":
+            self._colnames = names
+        elif type == "term":
+            self._terms = names
+        else:
+            raise ValueError(f"Type must be 'column' or 'term', got {type}")

--- a/src/tabmat/dense_matrix.py
+++ b/src/tabmat/dense_matrix.py
@@ -117,7 +117,7 @@ class DenseMatrix(MatrixBase):
     def __getitem__(self, key):
         """Return a subset of the matrix."""
         result = super().__getitem__(key)
-        if len(key) == 2:
+        if isinstance(key, tuple) and len(key) == 2:
             result._colnames = list(np.array(self._colnames)[key[1]])
             result._terms = list(np.array(self._terms)[key[1]])
         return result

--- a/src/tabmat/dense_matrix.py
+++ b/src/tabmat/dense_matrix.py
@@ -113,11 +113,19 @@ class DenseMatrix(MatrixBase):
 
     def astype(self, dtype, order="K", casting="unsafe", copy=True):
         """Copy of the array, cast to a specified type."""
-        return type(self)(self._array.astype(dtype, order, casting, copy))
+        return type(self)(
+            self._array.astype(dtype, order, casting, copy),
+            column_names=self.column_names,
+            term_names=self.term_names,
+        )
 
     def getcol(self, i):
         """Return matrix column at specified index."""
-        return type(self)(self._array[:, [i]])
+        return type(self)(
+            self._array[:, [i]],
+            column_names=[self.column_names[i]],
+            term_names=[self.term_names[i]],
+        )
 
     def toarray(self):
         """Return array representation of matrix."""
@@ -235,8 +243,16 @@ class DenseMatrix(MatrixBase):
         This assumes that ``other`` is a vector of size ``self.shape[0]``.
         """
         if np.asanyarray(other).ndim == 1:
-            return type(self)(self._array.__mul__(other[:, np.newaxis]))
-        return type(self)(self._array.__mul__(other))
+            return type(self)(
+                self._array.__mul__(other[:, np.newaxis]),
+                column_names=self.column_names,
+                term_names=self.term_names,
+            )
+        return type(self)(
+            self._array.__mul__(other),
+            column_names=self.column_names,
+            term_names=self.term_names,
+        )
 
     def get_names(
         self,

--- a/src/tabmat/dense_matrix.py
+++ b/src/tabmat/dense_matrix.py
@@ -67,7 +67,16 @@ class DenseMatrix(MatrixBase):
         # Always return a 2d array
         key = tuple([key_i] if np.isscalar(key_i) else key_i for key_i in key)
 
-        return type(self)(self._array.__getitem__(key))
+        if len(key) == 2:
+            colnames = list(np.array(self._colnames)[key[1]].ravel())
+            terms = list(np.array(self._terms)[key[1]].ravel())
+        else:
+            colnames = self._colnames
+            terms = self._terms
+
+        return type(self)(
+            self._array.__getitem__(key), column_names=colnames, term_names=terms
+        )
 
     __array_ufunc__ = None
 
@@ -113,19 +122,6 @@ class DenseMatrix(MatrixBase):
     def astype(self, dtype, order="K", casting="unsafe", copy=True):
         """Copy of the array, cast to a specified type."""
         return type(self)(self._array.astype(dtype, order, casting, copy))
-
-    def __getitem__(self, key):
-        """Return a subset of the matrix."""
-        result = type(self)(self._array.__getitem__(key))
-        if isinstance(key, tuple) and len(key) == 2:
-            if key[1] is None:
-                # Handle np.newaxis
-                result._colnames = self._colnames
-                result._terms = self._terms
-            else:
-                result._colnames = list(np.array(self._colnames)[key[1]])
-                result._terms = list(np.array(self._terms)[key[1]])
-        return result
 
     def getcol(self, i):
         """Return matrix column at specified index."""

--- a/src/tabmat/dense_matrix.py
+++ b/src/tabmat/dense_matrix.py
@@ -246,7 +246,7 @@ class DenseMatrix(MatrixBase):
         return type(self)(self._array.__mul__(other))
 
     def get_column_names(
-        self, missing_prefix: str = "_col_", start_index: int = 0
+        self, missing_prefix: str = "_col_", indices: Optional[List[int]] = None
     ) -> List[str]:
         """Get column names.
 
@@ -258,23 +258,24 @@ class DenseMatrix(MatrixBase):
         ----------
         missing_prefix
             Prefix to use for columns that do not have a name.
-        start_index
-            Index to start from when creating default names.
+        indices
+            The indices used for columns that do not have a name. If ``None``,
+            then the indices are ``list(range(self.shape[1]))``.
 
         Returns
         -------
         list of str
             Column names.
         """
+        if indices is None:
+            indices = list(range(self.shape[1]))
         colnames = np.array(self._colnames)
-        default_colnames = np.array(
-            [f"{missing_prefix}{start_index + i}" for i in range(self.shape[1])]
-        )
+        default_colnames = np.array([f"{missing_prefix}{i}" for i in indices])
         colnames[colnames == None] = default_colnames[colnames == None]  # noqa: E711
         return list(colnames)
 
     def get_term_names(
-        self, missing_prefix: str = "_col_", start_index: int = 0
+        self, missing_prefix: str = "_col_", indices: Optional[List[int]] = None
     ) -> List[str]:
         """Get term names.
 
@@ -289,17 +290,18 @@ class DenseMatrix(MatrixBase):
         ----------
         missing_prefix
             Prefix to use for terms that do not have a name.
-        start_index
-            Index to start from when creating default names.
+        indices
+            The indices used for columns that do not have a name. If ``None``,
+            then the indices are ``list(range(self.shape[1]))``.
 
         Returns
         -------
         list of str
             Term names.
         """
+        if indices is None:
+            indices = list(range(self.shape[1]))
         terms = np.array(self._terms)
-        default_terms = np.array(
-            [f"{missing_prefix}{start_index + i}" for i in range(self.shape[1])]
-        )
+        default_terms = np.array([f"{missing_prefix}{i}" for i in indices])
         terms[terms == None] = default_terms[terms == None]  # noqa: E711
         return list(terms)

--- a/src/tabmat/dense_matrix.py
+++ b/src/tabmat/dense_matrix.py
@@ -248,9 +248,9 @@ class DenseMatrix(MatrixBase):
     def get_names(
         self,
         type: str = "column",
-        missing_prefix: str = "_col_",
+        missing_prefix: Optional[str] = None,
         indices: Optional[List[int]] = None,
-    ) -> List[str]:
+    ) -> List[Optional[str]]:
         """Get column names.
 
         For columns that do not have a name, a default name is created using the
@@ -264,15 +264,16 @@ class DenseMatrix(MatrixBase):
             a categorical submatrix is counted as a single term, whereas it is
             counted as multiple columns. Furthermore, matrices created from formulas
             have a difference between a column and term (c.f. ``formulaic`` docs).
-        missing_prefix
-            Prefix to use for columns that do not have a name.
+        missing_prefix: Optional[str], default None
+            Prefix to use for columns that do not have a name. If None, then no
+            default name is created.
         indices
             The indices used for columns that do not have a name. If ``None``,
             then the indices are ``list(range(self.shape[1]))``.
 
         Returns
         -------
-        list of str
+        List[Optional[str]]
             Column names.
         """
         if type == "column":
@@ -285,6 +286,8 @@ class DenseMatrix(MatrixBase):
         if indices is None:
             indices = list(range(self.shape[1]))
 
-        default_names = np.array([f"{missing_prefix}{i}" for i in indices])
-        names[names == None] = default_names[names == None]  # noqa: E711
+        if missing_prefix is not None:
+            default_names = np.array([f"{missing_prefix}{i}" for i in indices])
+            names[names == None] = default_names[names == None]  # noqa: E711
+
         return list(names)

--- a/src/tabmat/dense_matrix.py
+++ b/src/tabmat/dense_matrix.py
@@ -33,7 +33,7 @@ class DenseMatrix(MatrixBase):
 
     """
 
-    def __init__(self, input_array):
+    def __init__(self, input_array, column_names=None, term_names=None):
         input_array = np.asarray(input_array)
 
         if input_array.ndim == 1:
@@ -42,9 +42,23 @@ class DenseMatrix(MatrixBase):
             raise ValueError("Input array must be 1- or 2-dimensional")
 
         self._array = np.asarray(input_array)
+        width = self._array.shape[1]
 
-        self._colnames = [None] * input_array.shape[1]
-        self._terms = [None] * input_array.shape[1]
+        if column_names is not None:
+            if len(column_names) != width:
+                raise ValueError(
+                    f"Expected {width} column names, got {len(column_names)}"
+                )
+            self._colnames = column_names
+        else:
+            self._colnames = [None] * width
+
+        if term_names is not None:
+            if len(term_names) != width:
+                raise ValueError(f"Expected {width} term names, got {len(term_names)}")
+            self._terms = term_names
+        else:
+            self._terms = obj._colnames
 
     def __getitem__(self, key):
         if not isinstance(key, tuple):

--- a/src/tabmat/dense_matrix.py
+++ b/src/tabmat/dense_matrix.py
@@ -118,8 +118,13 @@ class DenseMatrix(MatrixBase):
         """Return a subset of the matrix."""
         result = type(self)(self._array.__getitem__(key))
         if isinstance(key, tuple) and len(key) == 2:
-            result._colnames = list(np.array(self._colnames)[key[1]])
-            result._terms = list(np.array(self._terms)[key[1]])
+            if key[1] is None:
+                # Handle np.newaxis
+                result._colnames = self._colnames
+                result._terms = self._terms
+            else:
+                result._colnames = list(np.array(self._colnames)[key[1]])
+                result._terms = list(np.array(self._terms)[key[1]])
         return result
 
     def getcol(self, i):

--- a/src/tabmat/dense_matrix.py
+++ b/src/tabmat/dense_matrix.py
@@ -114,6 +114,14 @@ class DenseMatrix(MatrixBase):
         """Copy of the array, cast to a specified type."""
         return type(self)(self._array.astype(dtype, order, casting, copy))
 
+    def __getitem__(self, key):
+        """Return a subset of the matrix."""
+        result = super().__getitem__(key)
+        if len(key) == 2:
+            result._colnames = list(np.array(self._colnames)[key[1]])
+            result._terms = list(np.array(self._terms)[key[1]])
+        return result
+
     def getcol(self, i):
         """Return matrix column at specified index."""
         return type(self)(self._array[:, [i]])

--- a/src/tabmat/dense_matrix.py
+++ b/src/tabmat/dense_matrix.py
@@ -245,8 +245,11 @@ class DenseMatrix(MatrixBase):
             return type(self)(self._array.__mul__(other[:, np.newaxis]))
         return type(self)(self._array.__mul__(other))
 
-    def get_column_names(
-        self, missing_prefix: str = "_col_", indices: Optional[List[int]] = None
+    def get_names(
+        self,
+        type: str = "column",
+        missing_prefix: str = "_col_",
+        indices: Optional[List[int]] = None,
     ) -> List[str]:
         """Get column names.
 
@@ -256,6 +259,11 @@ class DenseMatrix(MatrixBase):
 
         Parameters
         ----------
+        type: str {'column'|'term'}
+            Whether to get column names or term names. The main difference is that
+            a categorical submatrix is counted as a single term, whereas it is
+            counted as multiple columns. Furthermore, matrices created from formulas
+            have a difference between a column and term (c.f. ``formulaic`` docs).
         missing_prefix
             Prefix to use for columns that do not have a name.
         indices
@@ -267,41 +275,16 @@ class DenseMatrix(MatrixBase):
         list of str
             Column names.
         """
+        if type == "column":
+            names = np.array(self._colnames)
+        elif type == "term":
+            names = np.array(self._terms)
+        else:
+            raise ValueError(f"Type must be 'column' or 'term', got {type}")
+
         if indices is None:
             indices = list(range(self.shape[1]))
-        colnames = np.array(self._colnames)
-        default_colnames = np.array([f"{missing_prefix}{i}" for i in indices])
-        colnames[colnames == None] = default_colnames[colnames == None]  # noqa: E711
-        return list(colnames)
 
-    def get_term_names(
-        self, missing_prefix: str = "_col_", indices: Optional[List[int]] = None
-    ) -> List[str]:
-        """Get term names.
-
-        The main difference to ``get_column_names`` is that a categorical submatrix
-        is counted as a single term. Furthermore, matrices created from formulas
-        have a difference between a column and term (c.f. ``formulaic`` docs).
-        For terms that do not have a name, a default name is created using the
-        followig pattern: ``"{missing_prefix}{start_index + i}"`` where ``i`` is
-        the index of the term.
-
-        Parameters
-        ----------
-        missing_prefix
-            Prefix to use for terms that do not have a name.
-        indices
-            The indices used for columns that do not have a name. If ``None``,
-            then the indices are ``list(range(self.shape[1]))``.
-
-        Returns
-        -------
-        list of str
-            Term names.
-        """
-        if indices is None:
-            indices = list(range(self.shape[1]))
-        terms = np.array(self._terms)
-        default_terms = np.array([f"{missing_prefix}{i}" for i in indices])
-        terms[terms == None] = default_terms[terms == None]  # noqa: E711
-        return list(terms)
+        default_names = np.array([f"{missing_prefix}{i}" for i in indices])
+        names[names == None] = default_names[names == None]  # noqa: E711
+        return list(names)

--- a/src/tabmat/dense_matrix.py
+++ b/src/tabmat/dense_matrix.py
@@ -43,6 +43,9 @@ class DenseMatrix(MatrixBase):
 
         self._array = np.asarray(input_array)
 
+        self._colnames = [None] * input_array.shape[1]
+        self._terms = [None] * input_array.shape[1]
+
     def __getitem__(self, key):
         if not isinstance(key, tuple):
             key = (key,)
@@ -219,3 +222,62 @@ class DenseMatrix(MatrixBase):
         if np.asanyarray(other).ndim == 1:
             return type(self)(self._array.__mul__(other[:, np.newaxis]))
         return type(self)(self._array.__mul__(other))
+
+    def get_column_names(
+        self, missing_prefix: str = "_col_", start_index: int = 0
+    ) -> List[str]:
+        """Get column names.
+
+        For columns that do not have a name, a default name is created using the
+        followig pattern: ``"{missing_prefix}{start_index + i}"`` where ``i`` is
+        the index of the column.
+
+        Parameters
+        ----------
+        missing_prefix
+            Prefix to use for columns that do not have a name.
+        start_index
+            Index to start from when creating default names.
+
+        Returns
+        -------
+        list of str
+            Column names.
+        """
+        colnames = np.array(self._colnames)
+        default_colnames = np.array(
+            [f"{missing_prefix}{start_index + i}" for i in range(self.shape[1])]
+        )
+        colnames[colnames == None] = default_colnames[colnames == None]  # noqa: E711
+        return list(colnames)
+
+    def get_term_names(
+        self, missing_prefix: str = "_col_", start_index: int = 0
+    ) -> List[str]:
+        """Get term names.
+
+        The main difference to ``get_column_names`` is that a categorical submatrix
+        is counted as a single term. Furthermore, matrices created from formulas
+        have a difference between a column and term (c.f. ``formulaic`` docs).
+        For terms that do not have a name, a default name is created using the
+        followig pattern: ``"{missing_prefix}{start_index + i}"`` where ``i`` is
+        the index of the term.
+
+        Parameters
+        ----------
+        missing_prefix
+            Prefix to use for terms that do not have a name.
+        start_index
+            Index to start from when creating default names.
+
+        Returns
+        -------
+        list of str
+            Term names.
+        """
+        terms = np.array(self._terms)
+        default_terms = np.array(
+            [f"{missing_prefix}{start_index + i}" for i in range(self.shape[1])]
+        )
+        terms[terms == None] = default_terms[terms == None]  # noqa: E711
+        return list(terms)

--- a/src/tabmat/matrix_base.py
+++ b/src/tabmat/matrix_base.py
@@ -164,6 +164,57 @@ class MatrixBase(ABC):
     def __getitem__(self, item):
         pass
 
+    @abstractmethod
+    def get_column_names(
+        self, missing_prefix: str = "_col_", start_index: int = 0
+    ) -> List[str]:
+        """Get column names.
+
+        For columns that do not have a name, a default name is created using the
+        followig pattern: ``"{missing_prefix}{start_index + i}"`` where ``i`` is
+        the index of the column.
+
+        Parameters
+        ----------
+        missing_prefix
+            Prefix to use for columns that do not have a name.
+        start_index
+            Index to start from when creating default names.
+
+        Returns
+        -------
+        list of str
+            Column names.
+        """
+        pass
+
+    @abstractmethod
+    def get_term_names(
+        self, missing_prefix: str = "_col_", start_index: int = 0
+    ) -> List[str]:
+        """Get term names.
+
+        The main difference to ``get_column_names`` is that a categorical submatrix
+        is counted as a single term. Furthermore, matrices created from formulas
+        have a difference between a column and term (c.f. ``formulaic`` docs).
+        For terms that do not have a name, a default name is created using the
+        followig pattern: ``"{missing_prefix}{start_index + i}"`` where ``i`` is
+        the index of the term.
+
+        Parameters
+        ----------
+        missing_prefix
+            Prefix to use for terms that do not have a name.
+        start_index
+            Index to start from when creating default names.
+
+        Returns
+        -------
+        list of str
+            Term names.
+        """
+        pass
+
     # Higher priority than numpy arrays, so behavior for funcs like "@" defaults to the
     # behavior of this class
     __array_priority__ = 11

--- a/src/tabmat/matrix_base.py
+++ b/src/tabmat/matrix_base.py
@@ -168,9 +168,9 @@ class MatrixBase(ABC):
     def get_names(
         self,
         type: str = "column",
-        missing_prefix: str = "_col_",
+        missing_prefix: Optional[str] = None,
         indices: Optional[List[int]] = None,
-    ) -> List[str]:
+    ) -> List[Optional[str]]:
         """Get column names.
 
         For columns that do not have a name, a default name is created using the
@@ -184,15 +184,16 @@ class MatrixBase(ABC):
             a categorical submatrix is counted as a single term, whereas it is
             counted as multiple columns. Furthermore, matrices created from formulas
             have a difference between a column and term (c.f. ``formulaic`` docs).
-        missing_prefix
-            Prefix to use for columns that do not have a name.
+        missing_prefix: Optional[str], default None
+            Prefix to use for columns that do not have a name. If None, then no
+            default name is created.
         indices
             The indices used for columns that do not have a name. If ``None``,
             then the indices are ``list(range(self.shape[1]))``.
 
         Returns
         -------
-        list of str
+        List[Optional[str]]
             Column names.
         """
         pass

--- a/src/tabmat/matrix_base.py
+++ b/src/tabmat/matrix_base.py
@@ -165,8 +165,11 @@ class MatrixBase(ABC):
         pass
 
     @abstractmethod
-    def get_column_names(
-        self, missing_prefix: str = "_col_", indices: Optional[List[int]] = None
+    def get_names(
+        self,
+        type: str = "column",
+        missing_prefix: str = "_col_",
+        indices: Optional[List[int]] = None,
     ) -> List[str]:
         """Get column names.
 
@@ -176,6 +179,11 @@ class MatrixBase(ABC):
 
         Parameters
         ----------
+        type: str {'column'|'term'}
+            Whether to get column names or term names. The main difference is that
+            a categorical submatrix is counted as a single term, whereas it is
+            counted as multiple columns. Furthermore, matrices created from formulas
+            have a difference between a column and term (c.f. ``formulaic`` docs).
         missing_prefix
             Prefix to use for columns that do not have a name.
         indices
@@ -186,34 +194,6 @@ class MatrixBase(ABC):
         -------
         list of str
             Column names.
-        """
-        pass
-
-    @abstractmethod
-    def get_term_names(
-        self, missing_prefix: str = "_col_", indices: Optional[List[int]] = None
-    ) -> List[str]:
-        """Get term names.
-
-        The main difference to ``get_column_names`` is that a categorical submatrix
-        is counted as a single term. Furthermore, matrices created from formulas
-        have a difference between a column and term (c.f. ``formulaic`` docs).
-        For terms that do not have a name, a default name is created using the
-        followig pattern: ``"{missing_prefix}{start_index + i}"`` where ``i`` is
-        the index of the term.
-
-        Parameters
-        ----------
-        missing_prefix
-            Prefix to use for terms that do not have a name.
-        indices
-            The indices used for columns that do not have a name. If ``None``,
-            then the indices are ``list(range(self.shape[1]))``.
-
-        Returns
-        -------
-        list of str
-            Term names.
         """
         pass
 

--- a/src/tabmat/matrix_base.py
+++ b/src/tabmat/matrix_base.py
@@ -166,7 +166,7 @@ class MatrixBase(ABC):
 
     @abstractmethod
     def get_column_names(
-        self, missing_prefix: str = "_col_", start_index: int = 0
+        self, missing_prefix: str = "_col_", indices: Optional[List[int]] = None
     ) -> List[str]:
         """Get column names.
 
@@ -178,8 +178,9 @@ class MatrixBase(ABC):
         ----------
         missing_prefix
             Prefix to use for columns that do not have a name.
-        start_index
-            Index to start from when creating default names.
+        indices
+            The indices used for columns that do not have a name. If ``None``,
+            then the indices are ``list(range(self.shape[1]))``.
 
         Returns
         -------
@@ -190,7 +191,7 @@ class MatrixBase(ABC):
 
     @abstractmethod
     def get_term_names(
-        self, missing_prefix: str = "_col_", start_index: int = 0
+        self, missing_prefix: str = "_col_", indices: Optional[List[int]] = None
     ) -> List[str]:
         """Get term names.
 
@@ -205,8 +206,9 @@ class MatrixBase(ABC):
         ----------
         missing_prefix
             Prefix to use for terms that do not have a name.
-        start_index
-            Index to start from when creating default names.
+        indices
+            The indices used for columns that do not have a name. If ``None``,
+            then the indices are ``list(range(self.shape[1]))``.
 
         Returns
         -------

--- a/src/tabmat/matrix_base.py
+++ b/src/tabmat/matrix_base.py
@@ -198,6 +198,42 @@ class MatrixBase(ABC):
         """
         pass
 
+    def set_names(self, names: Union[str, List[Optional[str]]], type: str = "column"):
+        """Set column names.
+
+        Parameters
+        ----------
+        names: List[Optional[str]]
+            Names to set.
+        type: str {'column'|'term'}
+            Whether to set column names or term names. The main difference is that
+            a categorical submatrix is counted as a single term, whereas it is
+            counted as multiple columns. Furthermore, matrices created from formulas
+            have a difference between a column and term (c.f. ``formulaic`` docs).
+        """
+        pass
+
+    @property
+    def column_names(self):
+        """Column names of the matrix."""
+        return self.get_names(type="column")
+
+    @column_names.setter
+    def column_names(self, names: List[Optional[str]]):
+        self.set_names(names, type="column")
+
+    @property
+    def term_names(self):
+        """Term names of the matrix.
+
+        For differences between column names and term names, see ``get_names``.
+        """
+        return self.get_names(type="term")
+
+    @term_names.setter
+    def term_names(self, names: List[Optional[str]]):
+        self.set_names(names, type="term")
+
     # Higher priority than numpy arrays, so behavior for funcs like "@" defaults to the
     # behavior of this class
     __array_priority__ = 11

--- a/src/tabmat/sparse_matrix.py
+++ b/src/tabmat/sparse_matrix.py
@@ -325,35 +325,6 @@ class SparseMatrix(MatrixBase):
             return type(self)(self._array.multiply(other[:, np.newaxis]))
         return type(self)(self._array.multiply(other))
 
-    def get_column_names(
-        self, missing_prefix: str = "_col_", indices: Optional[List[int]] = None
-    ) -> List[str]:
-        """Get column names.
-
-        For columns that do not have a name, a default name is created using the
-        followig pattern: ``"{missing_prefix}{start_index + i}"`` where ``i`` is
-        the index of the column.
-
-        Parameters
-        ----------
-        missing_prefix
-            Prefix to use for columns that do not have a name.
-        indices
-            The indices used for columns that do not have a name. If ``None``,
-            then the indices are ``list(range(self.shape[1]))``.
-
-        Returns
-        -------
-        list of str
-            Column names.
-        """
-        if indices is None:
-            indices = list(range(self.shape[1]))
-        colnames = np.array(self._colnames)
-        default_colnames = np.array([f"{missing_prefix}{i}" for i in indices])
-        colnames[colnames == None] = default_colnames[colnames == None]  # noqa: E711
-        return list(colnames)
-
     def get_names(
         self,
         type: str = "column",
@@ -393,7 +364,7 @@ class SparseMatrix(MatrixBase):
             raise ValueError(f"Type must be 'column' or 'term', got {type}")
 
         if indices is None:
-            indices = list(range(self.shape[1]))
+            indices = list(range(len(self._colnames)))
 
         if missing_prefix is not None:
             default_names = np.array([f"{missing_prefix}{i}" for i in indices])

--- a/src/tabmat/sparse_matrix.py
+++ b/src/tabmat/sparse_matrix.py
@@ -354,22 +354,27 @@ class SparseMatrix(MatrixBase):
         colnames[colnames == None] = default_colnames[colnames == None]  # noqa: E711
         return list(colnames)
 
-    def get_term_names(
-        self, missing_prefix: str = "_col_", indices: Optional[List[int]] = None
+    def get_names(
+        self,
+        type: str = "column",
+        missing_prefix: str = "_col_",
+        indices: Optional[List[int]] = None,
     ) -> List[str]:
-        """Get term names.
+        """Get column names.
 
-        The main difference to ``get_column_names`` is that a categorical submatrix
-        is counted as a single term. Furthermore, matrices created from formulas
-        have a difference between a column and term (c.f. ``formulaic`` docs).
-        For terms that do not have a name, a default name is created using the
+        For columns that do not have a name, a default name is created using the
         followig pattern: ``"{missing_prefix}{start_index + i}"`` where ``i`` is
-        the index of the term.
+        the index of the column.
 
         Parameters
         ----------
+        type: str {'column'|'term'}
+            Whether to get column names or term names. The main difference is that
+            a categorical submatrix is counted as a single term, whereas it is
+            counted as multiple columns. Furthermore, matrices created from formulas
+            have a difference between a column and term (c.f. ``formulaic`` docs).
         missing_prefix
-            Prefix to use for terms that do not have a name.
+            Prefix to use for columns that do not have a name.
         indices
             The indices used for columns that do not have a name. If ``None``,
             then the indices are ``list(range(self.shape[1]))``.
@@ -377,11 +382,18 @@ class SparseMatrix(MatrixBase):
         Returns
         -------
         list of str
-            Term names.
+            Column names.
         """
+        if type == "column":
+            names = np.array(self._colnames)
+        elif type == "term":
+            names = np.array(self._terms)
+        else:
+            raise ValueError(f"Type must be 'column' or 'term', got {type}")
+
         if indices is None:
             indices = list(range(self.shape[1]))
-        terms = np.array(self._terms)
-        default_terms = np.array([f"{missing_prefix}{i}" for i in indices])
-        terms[terms == None] = default_terms[terms == None]  # noqa: E711
-        return list(terms)
+
+        default_names = np.array([f"{missing_prefix}{i}" for i in indices])
+        names[names == None] = default_names[names == None]  # noqa: E711
+        return list(names)

--- a/src/tabmat/sparse_matrix.py
+++ b/src/tabmat/sparse_matrix.py
@@ -30,7 +30,15 @@ class SparseMatrix(MatrixBase):
     SparseMatrix is instantiated in the same way as scipy.sparse.csc_matrix.
     """
 
-    def __init__(self, arg1, shape=None, dtype=None, copy=False):
+    def __init__(
+        self,
+        arg1,
+        shape=None,
+        dtype=None,
+        copy=False,
+        column_names=None,
+        term_names=None,
+    ):
         self._array = sps.csc_matrix(arg1, shape, dtype, copy)
 
         self.idx_dtype = max(self._array.indices.dtype, self._array.indptr.dtype)
@@ -44,8 +52,23 @@ class SparseMatrix(MatrixBase):
             self._array.sort_indices()
         self._array_csr = None
 
-        self._colnames = [None] * self.shape[1]
-        self._terms = [None] * self.shape[1]
+        if column_names is not None:
+            if len(column_names) != self.shape[1]:
+                raise ValueError(
+                    f"Expected {self.shape[1]} column names, got {len(column_names)}"
+                )
+            self._colnames = column_names
+        else:
+            self._colnames = [None] * self.shape[1]
+
+        if term_names is not None:
+            if len(term_names) != self.shape[1]:
+                raise ValueError(
+                    f"Expected {self.shape[1]} term names, got {len(term_names)}"
+                )
+            self._terms = term_names
+        else:
+            self._terms = self._colnames
 
 
     def __getitem__(self, key):

--- a/src/tabmat/sparse_matrix.py
+++ b/src/tabmat/sparse_matrix.py
@@ -400,3 +400,29 @@ class SparseMatrix(MatrixBase):
             names[names == None] = default_names[names == None]  # noqa: E711
 
         return list(names)
+
+    def set_names(self, names: Union[str, List[Optional[str]]], type: str = "column"):
+        """Set column names.
+
+        Parameters
+        ----------
+        names: List[Optional[str]]
+            Names to set.
+        type: str {'column'|'term'}
+            Whether to set column names or term names. The main difference is that
+            a categorical submatrix is counted as a single term, whereas it is
+            counted as multiple columns. Furthermore, matrices created from formulas
+            have a difference between a column and term (c.f. ``formulaic`` docs).
+        """
+        if isinstance(names, str):
+            names = [names]
+
+        if len(names) != self.shape[1]:
+            raise ValueError(f"Length of names must be {self.shape[1]}")
+
+        if type == "column":
+            self._colnames = names
+        elif type == "term":
+            self._terms = names
+        else:
+            raise ValueError(f"Type must be 'column' or 'term', got {type}")

--- a/src/tabmat/sparse_matrix.py
+++ b/src/tabmat/sparse_matrix.py
@@ -44,6 +44,10 @@ class SparseMatrix(MatrixBase):
             self._array.sort_indices()
         self._array_csr = None
 
+        self._colnames = [None] * self.shape[1]
+        self._terms = [None] * self.shape[1]
+
+
     def __getitem__(self, key):
         if not isinstance(key, tuple):
             key = (key,)
@@ -287,3 +291,62 @@ class SparseMatrix(MatrixBase):
         if other.ndim == 1:
             return type(self)(self._array.multiply(other[:, np.newaxis]))
         return type(self)(self._array.multiply(other))
+
+    def get_column_names(
+        self, missing_prefix: str = "_col_", start_index: int = 0
+    ) -> List[str]:
+        """Get column names.
+
+        For columns that do not have a name, a default name is created using the
+        followig pattern: ``"{missing_prefix}{start_index + i}"`` where ``i`` is
+        the index of the column.
+
+        Parameters
+        ----------
+        missing_prefix
+            Prefix to use for columns that do not have a name.
+        start_index
+            Index to start from when creating default names.
+
+        Returns
+        -------
+        list of str
+            Column names.
+        """
+        colnames = np.array(self._colnames)
+        default_colnames = np.array(
+            [f"{missing_prefix}{start_index + i}" for i in range(self.shape[1])]
+        )
+        colnames[colnames == None] = default_colnames[colnames == None]  # noqa: E711
+        return list(colnames)
+
+    def get_term_names(
+        self, missing_prefix: str = "_col_", start_index: int = 0
+    ) -> List[str]:
+        """Get term names.
+
+        The main difference to ``get_column_names`` is that a categorical submatrix
+        is counted as a single term. Furthermore, matrices created from formulas
+        have a difference between a column and term (c.f. ``formulaic`` docs).
+        For terms that do not have a name, a default name is created using the
+        followig pattern: ``"{missing_prefix}{start_index + i}"`` where ``i`` is
+        the index of the term.
+
+        Parameters
+        ----------
+        missing_prefix
+            Prefix to use for terms that do not have a name.
+        start_index
+            Index to start from when creating default names.
+
+        Returns
+        -------
+        list of str
+            Term names.
+        """
+        terms = np.array(self._terms)
+        default_terms = np.array(
+            [f"{missing_prefix}{start_index + i}" for i in range(self.shape[1])]
+        )
+        terms[terms == None] = default_terms[terms == None]  # noqa: E711
+        return list(terms)

--- a/src/tabmat/sparse_matrix.py
+++ b/src/tabmat/sparse_matrix.py
@@ -147,7 +147,11 @@ class SparseMatrix(MatrixBase):
 
     def getcol(self, i):
         """Return matrix column at specified index."""
-        return type(self)(self._array.getcol(i))
+        return type(self)(
+            self._array.getcol(i),
+            column_names=[self.column_names[i]],
+            term_names=[self.term_names[i]],
+        )
 
     def unpack(self):
         """Return the underlying scipy.sparse.csc_matrix."""
@@ -311,9 +315,17 @@ class SparseMatrix(MatrixBase):
         from the parent class except that ``other`` is assumed to be a vector of size
         ``self.shape[0]``.
         """
-        if other.ndim == 1:
-            return type(self)(self._array.multiply(other[:, np.newaxis]))
-        return type(self)(self._array.multiply(other))
+        if np.asanyarray(other).ndim == 1:
+            return type(self)(
+                self._array.multiply(other[:, np.newaxis]),
+                column_names=self.column_names,
+                term_names=self.term_names,
+            )
+        return type(self)(
+            self._array.multiply(other),
+            column_names=self.column_names,
+            term_names=self.term_names,
+        )
 
     def get_names(
         self,

--- a/src/tabmat/sparse_matrix.py
+++ b/src/tabmat/sparse_matrix.py
@@ -357,9 +357,9 @@ class SparseMatrix(MatrixBase):
     def get_names(
         self,
         type: str = "column",
-        missing_prefix: str = "_col_",
+        missing_prefix: Optional[str] = None,
         indices: Optional[List[int]] = None,
-    ) -> List[str]:
+    ) -> List[Optional[str]]:
         """Get column names.
 
         For columns that do not have a name, a default name is created using the
@@ -373,15 +373,16 @@ class SparseMatrix(MatrixBase):
             a categorical submatrix is counted as a single term, whereas it is
             counted as multiple columns. Furthermore, matrices created from formulas
             have a difference between a column and term (c.f. ``formulaic`` docs).
-        missing_prefix
-            Prefix to use for columns that do not have a name.
+        missing_prefix: Optional[str], default None
+            Prefix to use for columns that do not have a name. If None, then no
+            default name is created.
         indices
             The indices used for columns that do not have a name. If ``None``,
             then the indices are ``list(range(self.shape[1]))``.
 
         Returns
         -------
-        list of str
+        List[Optional[str]]
             Column names.
         """
         if type == "column":
@@ -394,6 +395,8 @@ class SparseMatrix(MatrixBase):
         if indices is None:
             indices = list(range(self.shape[1]))
 
-        default_names = np.array([f"{missing_prefix}{i}" for i in indices])
-        names[names == None] = default_names[names == None]  # noqa: E711
+        if missing_prefix is not None:
+            default_names = np.array([f"{missing_prefix}{i}" for i in indices])
+            names[names == None] = default_names[names == None]  # noqa: E711
+
         return list(names)

--- a/src/tabmat/sparse_matrix.py
+++ b/src/tabmat/sparse_matrix.py
@@ -70,7 +70,6 @@ class SparseMatrix(MatrixBase):
         else:
             self._terms = self._colnames
 
-
     def __getitem__(self, key):
         if not isinstance(key, tuple):
             key = (key,)
@@ -78,7 +77,18 @@ class SparseMatrix(MatrixBase):
         # Always return a 2d array
         key = tuple([key_i] if np.isscalar(key_i) else key_i for key_i in key)
 
-        return type(self)(self._array.__getitem__(key))
+        if len(key) == 2:
+            colnames = list(np.array(self._colnames)[key[1]])
+            terms = list(np.array(self._terms)[key[1]])
+        else:
+            colnames = self._colnames
+            terms = self._terms
+
+        return type(self)(
+            self._array.__getitem__(key),
+            column_names=colnames,
+            term_names=terms
+        )
 
     def __matmul__(self, other):
         return self._array.__matmul__(other)

--- a/src/tabmat/sparse_matrix.py
+++ b/src/tabmat/sparse_matrix.py
@@ -78,16 +78,14 @@ class SparseMatrix(MatrixBase):
         key = tuple([key_i] if np.isscalar(key_i) else key_i for key_i in key)
 
         if len(key) == 2:
-            colnames = list(np.array(self._colnames)[key[1]])
-            terms = list(np.array(self._terms)[key[1]])
+            colnames = list(np.array(self._colnames)[key[1]].ravel())
+            terms = list(np.array(self._terms)[key[1]].ravel())
         else:
             colnames = self._colnames
             terms = self._terms
 
         return type(self)(
-            self._array.__getitem__(key),
-            column_names=colnames,
-            term_names=terms
+            self._array.__getitem__(key), column_names=colnames, term_names=terms
         )
 
     def __matmul__(self, other):

--- a/src/tabmat/sparse_matrix.py
+++ b/src/tabmat/sparse_matrix.py
@@ -326,7 +326,7 @@ class SparseMatrix(MatrixBase):
         return type(self)(self._array.multiply(other))
 
     def get_column_names(
-        self, missing_prefix: str = "_col_", start_index: int = 0
+        self, missing_prefix: str = "_col_", indices: Optional[List[int]] = None
     ) -> List[str]:
         """Get column names.
 
@@ -338,23 +338,24 @@ class SparseMatrix(MatrixBase):
         ----------
         missing_prefix
             Prefix to use for columns that do not have a name.
-        start_index
-            Index to start from when creating default names.
+        indices
+            The indices used for columns that do not have a name. If ``None``,
+            then the indices are ``list(range(self.shape[1]))``.
 
         Returns
         -------
         list of str
             Column names.
         """
+        if indices is None:
+            indices = list(range(self.shape[1]))
         colnames = np.array(self._colnames)
-        default_colnames = np.array(
-            [f"{missing_prefix}{start_index + i}" for i in range(self.shape[1])]
-        )
+        default_colnames = np.array([f"{missing_prefix}{i}" for i in indices])
         colnames[colnames == None] = default_colnames[colnames == None]  # noqa: E711
         return list(colnames)
 
     def get_term_names(
-        self, missing_prefix: str = "_col_", start_index: int = 0
+        self, missing_prefix: str = "_col_", indices: Optional[List[int]] = None
     ) -> List[str]:
         """Get term names.
 
@@ -369,17 +370,18 @@ class SparseMatrix(MatrixBase):
         ----------
         missing_prefix
             Prefix to use for terms that do not have a name.
-        start_index
-            Index to start from when creating default names.
+        indices
+            The indices used for columns that do not have a name. If ``None``,
+            then the indices are ``list(range(self.shape[1]))``.
 
         Returns
         -------
         list of str
             Term names.
         """
+        if indices is None:
+            indices = list(range(self.shape[1]))
         terms = np.array(self._terms)
-        default_terms = np.array(
-            [f"{missing_prefix}{start_index + i}" for i in range(self.shape[1])]
-        )
+        default_terms = np.array([f"{missing_prefix}{i}" for i in indices])
         terms[terms == None] = default_terms[terms == None]  # noqa: E711
         return list(terms)

--- a/src/tabmat/sparse_matrix.py
+++ b/src/tabmat/sparse_matrix.py
@@ -33,7 +33,7 @@ class SparseMatrix(MatrixBase):
 
     def __init__(
         self,
-        array,
+        input_array,
         shape=None,
         dtype=None,
         copy=False,

--- a/src/tabmat/split_matrix.py
+++ b/src/tabmat/split_matrix.py
@@ -487,7 +487,7 @@ class SplitMatrix(MatrixBase):
     __array_priority__ = 13
 
     def get_column_names(
-        self, missing_prefix: str = "_col_", start_index: int = 0
+        self, missing_prefix: str = "_col_", indices: Optional[List[int]] = None
     ) -> List[str]:
         """Get column names.
 
@@ -499,8 +499,8 @@ class SplitMatrix(MatrixBase):
         ----------
         missing_prefix
             Prefix to use for columns that do not have a name.
-        start_index
-            Index to start from when creating default names.
+        indices
+            Ignored.
 
         Returns
         -------
@@ -509,15 +509,11 @@ class SplitMatrix(MatrixBase):
         """
         column_names = np.empty(self.shape[1], dtype=object)
         for idx, mat in zip(self.indices, self.matrices):
-            column_names[idx] = mat.get_column_names(missing_prefix, start_index)
-            if isinstance(mat, CategoricalMatrix):
-                start_index += 1
-            else:
-                start_index += mat.shape[1]
+            column_names[idx] = mat.get_column_names(missing_prefix, idx)
         return list(column_names)
 
     def get_term_names(
-        self, missing_prefix: str = "_col_", start_index: int = 0
+        self, missing_prefix: str = "_col_", indices: Optional[List[int]] = None
     ) -> List[str]:
         """Get term names.
 
@@ -532,8 +528,8 @@ class SplitMatrix(MatrixBase):
         ----------
         missing_prefix
             Prefix to use for terms that do not have a name.
-        start_index
-            Index to start from when creating default names.
+        indices
+            Ignored.
 
         Returns
         -------
@@ -542,9 +538,5 @@ class SplitMatrix(MatrixBase):
         """
         term_names = np.empty(self.shape[1], dtype=object)
         for idx, mat in zip(self.indices, self.matrices):
-            term_names[idx] = mat.get_term_names(missing_prefix, start_index)
-            if isinstance(mat, CategoricalMatrix):
-                start_index += 1
-            else:
-                start_index += mat.shape[1]
+            term_names[idx] = mat.get_term_names(missing_prefix, idx)
         return list(term_names)

--- a/src/tabmat/split_matrix.py
+++ b/src/tabmat/split_matrix.py
@@ -114,10 +114,10 @@ def _combine_matrices(matrices, indices):
             new_matrix = mat_type_(stack_fn([matrices[i] for i in this_type_matrices]))
             new_indices = np.concatenate([indices[i] for i in this_type_matrices])
             new_colnames = np.concatenate(
-                np.array([matrices[i]._colnames for i in this_type_matrices])
+                [np.array(matrices[i]._colnames) for i in this_type_matrices]
             )
             new_terms = np.concatenate(
-                np.array([matrices[i]._terms for i in this_type_matrices])
+                [np.array(matrices[i]._terms) for i in this_type_matrices]
             )
             sorter = np.argsort(new_indices)
             sorted_matrix = new_matrix[:, sorter]

--- a/src/tabmat/split_matrix.py
+++ b/src/tabmat/split_matrix.py
@@ -489,9 +489,9 @@ class SplitMatrix(MatrixBase):
     def get_names(
         self,
         type: str = "column",
-        missing_prefix: str = "_col_",
+        missing_prefix: Optional[str] = None,
         indices: Optional[List[int]] = None,
-    ) -> List[str]:
+    ) -> List[Optional[str]]:
         """Get column names.
 
         For columns that do not have a name, a default name is created using the
@@ -505,15 +505,16 @@ class SplitMatrix(MatrixBase):
             a categorical submatrix is counted as a single term, whereas it is
             counted as multiple columns. Furthermore, matrices created from formulas
             have a difference between a column and term (c.f. ``formulaic`` docs).
-        missing_prefix
-            Prefix to use for columns that do not have a name.
+        missing_prefix: Optional[str], default None
+            Prefix to use for columns that do not have a name. If None, then no
+            default name is created.
         indices
             The indices used for columns that do not have a name. If ``None``,
             then the indices are ``list(range(self.shape[1]))``.
 
         Returns
         -------
-        list of str
+        List[Optional[str]]
             Column names.
         """
         names = np.empty(self.shape[1], dtype=object)

--- a/src/tabmat/split_matrix.py
+++ b/src/tabmat/split_matrix.py
@@ -521,3 +521,24 @@ class SplitMatrix(MatrixBase):
         for idx, mat in zip(self.indices, self.matrices):
             names[idx] = mat.get_names(type, missing_prefix, idx)
         return list(names)
+
+    def set_names(self, names: Union[str, List[Optional[str]]], type: str = "column"):
+        """Set column names.
+
+        Parameters
+        ----------
+        names: List[Optional[str]]
+            Names to set.
+        type: str {'column'|'term'}
+            Whether to set column names or term names. The main difference is that
+            a categorical submatrix is counted as a single term, whereas it is
+            counted as multiple columns. Furthermore, matrices created from formulas
+            have a difference between a column and term (c.f. ``formulaic`` docs).
+        """
+        names_array = np.array(names)
+
+        if len(names) != self.shape[1]:
+            raise ValueError(f"Length of names must be {self.shape[1]}")
+
+        for idx, mat in zip(self.indices, self.matrices):
+            mat.set_names(list(names_array[idx]), type)

--- a/src/tabmat/split_matrix.py
+++ b/src/tabmat/split_matrix.py
@@ -486,8 +486,11 @@ class SplitMatrix(MatrixBase):
 
     __array_priority__ = 13
 
-    def get_column_names(
-        self, missing_prefix: str = "_col_", indices: Optional[List[int]] = None
+    def get_names(
+        self,
+        type: str = "column",
+        missing_prefix: str = "_col_",
+        indices: Optional[List[int]] = None,
     ) -> List[str]:
         """Get column names.
 
@@ -497,46 +500,23 @@ class SplitMatrix(MatrixBase):
 
         Parameters
         ----------
+        type: str {'column'|'term'}
+            Whether to get column names or term names. The main difference is that
+            a categorical submatrix is counted as a single term, whereas it is
+            counted as multiple columns. Furthermore, matrices created from formulas
+            have a difference between a column and term (c.f. ``formulaic`` docs).
         missing_prefix
             Prefix to use for columns that do not have a name.
         indices
-            Ignored.
+            The indices used for columns that do not have a name. If ``None``,
+            then the indices are ``list(range(self.shape[1]))``.
 
         Returns
         -------
         list of str
             Column names.
         """
-        column_names = np.empty(self.shape[1], dtype=object)
+        names = np.empty(self.shape[1], dtype=object)
         for idx, mat in zip(self.indices, self.matrices):
-            column_names[idx] = mat.get_column_names(missing_prefix, idx)
-        return list(column_names)
-
-    def get_term_names(
-        self, missing_prefix: str = "_col_", indices: Optional[List[int]] = None
-    ) -> List[str]:
-        """Get term names.
-
-        The main difference to ``get_column_names`` is that a categorical submatrix
-        is counted as a single term. Furthermore, matrices created from formulas
-        have a difference between a column and term (c.f. ``formulaic`` docs).
-        For terms that do not have a name, a default name is created using the
-        followig pattern: ``"{missing_prefix}{start_index + i}"`` where ``i`` is
-        the index of the term.
-
-        Parameters
-        ----------
-        missing_prefix
-            Prefix to use for terms that do not have a name.
-        indices
-            Ignored.
-
-        Returns
-        -------
-        list of str
-            Term names.
-        """
-        term_names = np.empty(self.shape[1], dtype=object)
-        for idx, mat in zip(self.indices, self.matrices):
-            term_names[idx] = mat.get_term_names(missing_prefix, idx)
-        return list(term_names)
+            names[idx] = mat.get_names(type, missing_prefix, idx)
+        return list(names)

--- a/src/tabmat/split_matrix.py
+++ b/src/tabmat/split_matrix.py
@@ -113,8 +113,16 @@ def _combine_matrices(matrices, indices):
         if len(this_type_matrices) > 1:
             new_matrix = mat_type_(stack_fn([matrices[i] for i in this_type_matrices]))
             new_indices = np.concatenate([indices[i] for i in this_type_matrices])
+            new_colnames = np.concatenate(
+                np.array([matrices[i]._colnames for i in this_type_matrices])
+            )
+            new_terms = np.concatenate(
+                np.array([matrices[i]._terms for i in this_type_matrices])
+            )
             sorter = np.argsort(new_indices)
             sorted_matrix = new_matrix[:, sorter]
+            sorted_matrix._colnames = list(new_colnames[sorter])
+            sorted_matrix._terms = list(new_terms[sorter])
             sorted_indices = new_indices[sorter]
 
             assert sorted_matrix.shape[0] == n_row

--- a/src/tabmat/split_matrix.py
+++ b/src/tabmat/split_matrix.py
@@ -477,3 +477,66 @@ class SplitMatrix(MatrixBase):
         return out
 
     __array_priority__ = 13
+
+    def get_column_names(
+        self, missing_prefix: str = "_col_", start_index: int = 0
+    ) -> List[str]:
+        """Get column names.
+
+        For columns that do not have a name, a default name is created using the
+        followig pattern: ``"{missing_prefix}{start_index + i}"`` where ``i`` is
+        the index of the column.
+
+        Parameters
+        ----------
+        missing_prefix
+            Prefix to use for columns that do not have a name.
+        start_index
+            Index to start from when creating default names.
+
+        Returns
+        -------
+        list of str
+            Column names.
+        """
+        column_names = np.empty(self.shape[1], dtype=object)
+        for idx, mat in zip(self.indices, self.matrices):
+            column_names[idx] = mat.get_column_names(missing_prefix, start_index)
+            if isinstance(mat, CategoricalMatrix):
+                start_index += 1
+            else:
+                start_index += mat.shape[1]
+        return list(column_names)
+
+    def get_term_names(
+        self, missing_prefix: str = "_col_", start_index: int = 0
+    ) -> List[str]:
+        """Get term names.
+
+        The main difference to ``get_column_names`` is that a categorical submatrix
+        is counted as a single term. Furthermore, matrices created from formulas
+        have a difference between a column and term (c.f. ``formulaic`` docs).
+        For terms that do not have a name, a default name is created using the
+        followig pattern: ``"{missing_prefix}{start_index + i}"`` where ``i`` is
+        the index of the term.
+
+        Parameters
+        ----------
+        missing_prefix
+            Prefix to use for terms that do not have a name.
+        start_index
+            Index to start from when creating default names.
+
+        Returns
+        -------
+        list of str
+            Term names.
+        """
+        term_names = np.empty(self.shape[1], dtype=object)
+        for idx, mat in zip(self.indices, self.matrices):
+            term_names[idx] = mat.get_term_names(missing_prefix, start_index)
+            if isinstance(mat, CategoricalMatrix):
+                start_index += 1
+            else:
+                start_index += mat.shape[1]
+        return list(term_names)

--- a/src/tabmat/standardized_mat.py
+++ b/src/tabmat/standardized_mat.py
@@ -302,9 +302,9 @@ class StandardizedMatrix:
     def get_names(
         self,
         type: str = "column",
-        missing_prefix: str = "_col_",
+        missing_prefix: Optional[str] = None,
         indices: Optional[List[int]] = None,
-    ) -> List[str]:
+    ) -> List[Optional[str]]:
         """Get column names.
 
         For columns that do not have a name, a default name is created using the
@@ -318,15 +318,16 @@ class StandardizedMatrix:
             a categorical submatrix is counted as a single term, whereas it is
             counted as multiple columns. Furthermore, matrices created from formulas
             have a difference between a column and term (c.f. ``formulaic`` docs).
-        missing_prefix
-            Prefix to use for columns that do not have a name.
+        missing_prefix: Optional[str], default None
+            Prefix to use for columns that do not have a name. If None, then no
+            default name is created.
         indices
             The indices used for columns that do not have a name. If ``None``,
             then the indices are ``list(range(self.shape[1]))``.
 
         Returns
         -------
-        list of str
+        List[Optional[str]]
             Column names.
         """
         return self.mat.get_names(type, missing_prefix, indices)

--- a/src/tabmat/standardized_mat.py
+++ b/src/tabmat/standardized_mat.py
@@ -331,3 +331,39 @@ class StandardizedMatrix:
             Column names.
         """
         return self.mat.get_names(type, missing_prefix, indices)
+
+    def set_names(self, names: Union[str, List[Optional[str]]], type: str = "column"):
+        """Set column names.
+
+        Parameters
+        ----------
+        names: List[Optional[str]]
+            Names to set.
+        type: str {'column'|'term'}
+            Whether to set column names or term names. The main difference is that
+            a categorical submatrix is counted as a single term, whereas it is
+            counted as multiple columns. Furthermore, matrices created from formulas
+            have a difference between a column and term (c.f. ``formulaic`` docs).
+        """
+        self.mat.set_names(names, type)
+
+    @property
+    def column_names(self):
+        """Column names of the matrix."""
+        return self.get_names(type="column")
+
+    @column_names.setter
+    def column_names(self, names: List[Optional[str]]):
+        self.set_names(names, type="column")
+
+    @property
+    def term_names(self):
+        """Term names of the matrix.
+
+        For differences between column names and term names, see ``get_names``.
+        """
+        return self.get_names(type="term")
+
+    @term_names.setter
+    def term_names(self, names: List[Optional[str]]):
+        self.set_names(names, type="term")

--- a/src/tabmat/standardized_mat.py
+++ b/src/tabmat/standardized_mat.py
@@ -1,4 +1,4 @@
-from typing import List, Union
+from typing import List, Optional, Union
 
 import numpy as np
 from scipy import sparse as sps
@@ -300,7 +300,7 @@ class StandardizedMatrix:
         return out
 
     def get_column_names(
-        self, missing_prefix: str = "_col_", start_index: int = 0
+        self, missing_prefix: str = "_col_", indices: Optional[List[int]] = None
     ) -> List[str]:
         """Get column names.
 
@@ -312,18 +312,18 @@ class StandardizedMatrix:
         ----------
         missing_prefix
             Prefix to use for columns that do not have a name.
-        start_index
-            Index to start from when creating default names.
+        indices
+            Ignored.
 
         Returns
         -------
         list of str
             Column names.
         """
-        return self.mat.get_column_names(missing_prefix, start_index)
+        return self.mat.get_column_names(missing_prefix, indices)
 
     def get_term_names(
-        self, missing_prefix: str = "_col_", start_index: int = 0
+        self, missing_prefix: str = "_col_", indices: Optional[List[int]] = None
     ) -> List[str]:
         """Get term names.
 
@@ -338,12 +338,12 @@ class StandardizedMatrix:
         ----------
         missing_prefix
             Prefix to use for terms that do not have a name.
-        start_index
-            Index to start from when creating default names.
+        indices
+            Ignored.
 
         Returns
         -------
         list of str
             Term names.
         """
-        return self.mat.get_term_names(missing_prefix, start_index)
+        return self.mat.get_term_names(missing_prefix, indices)

--- a/src/tabmat/standardized_mat.py
+++ b/src/tabmat/standardized_mat.py
@@ -299,8 +299,11 @@ class StandardizedMatrix:
         """
         return out
 
-    def get_column_names(
-        self, missing_prefix: str = "_col_", indices: Optional[List[int]] = None
+    def get_names(
+        self,
+        type: str = "column",
+        missing_prefix: str = "_col_",
+        indices: Optional[List[int]] = None,
     ) -> List[str]:
         """Get column names.
 
@@ -310,40 +313,20 @@ class StandardizedMatrix:
 
         Parameters
         ----------
+        type: str {'column'|'term'}
+            Whether to get column names or term names. The main difference is that
+            a categorical submatrix is counted as a single term, whereas it is
+            counted as multiple columns. Furthermore, matrices created from formulas
+            have a difference between a column and term (c.f. ``formulaic`` docs).
         missing_prefix
             Prefix to use for columns that do not have a name.
         indices
-            Ignored.
+            The indices used for columns that do not have a name. If ``None``,
+            then the indices are ``list(range(self.shape[1]))``.
 
         Returns
         -------
         list of str
             Column names.
         """
-        return self.mat.get_column_names(missing_prefix, indices)
-
-    def get_term_names(
-        self, missing_prefix: str = "_col_", indices: Optional[List[int]] = None
-    ) -> List[str]:
-        """Get term names.
-
-        The main difference to ``get_column_names`` is that a categorical submatrix
-        is counted as a single term. Furthermore, matrices created from formulas
-        have a difference between a column and term (c.f. ``formulaic`` docs).
-        For terms that do not have a name, a default name is created using the
-        followig pattern: ``"{missing_prefix}{start_index + i}"`` where ``i`` is
-        the index of the term.
-
-        Parameters
-        ----------
-        missing_prefix
-            Prefix to use for terms that do not have a name.
-        indices
-            Ignored.
-
-        Returns
-        -------
-        list of str
-            Term names.
-        """
-        return self.mat.get_term_names(missing_prefix, indices)
+        return self.mat.get_names(type, missing_prefix, indices)

--- a/src/tabmat/standardized_mat.py
+++ b/src/tabmat/standardized_mat.py
@@ -298,3 +298,52 @@ class StandardizedMatrix:
         Mult: {self.mult}
         """
         return out
+
+    def get_column_names(
+        self, missing_prefix: str = "_col_", start_index: int = 0
+    ) -> List[str]:
+        """Get column names.
+
+        For columns that do not have a name, a default name is created using the
+        followig pattern: ``"{missing_prefix}{start_index + i}"`` where ``i`` is
+        the index of the column.
+
+        Parameters
+        ----------
+        missing_prefix
+            Prefix to use for columns that do not have a name.
+        start_index
+            Index to start from when creating default names.
+
+        Returns
+        -------
+        list of str
+            Column names.
+        """
+        return self.mat.get_column_names(missing_prefix, start_index)
+
+    def get_term_names(
+        self, missing_prefix: str = "_col_", start_index: int = 0
+    ) -> List[str]:
+        """Get term names.
+
+        The main difference to ``get_column_names`` is that a categorical submatrix
+        is counted as a single term. Furthermore, matrices created from formulas
+        have a difference between a column and term (c.f. ``formulaic`` docs).
+        For terms that do not have a name, a default name is created using the
+        followig pattern: ``"{missing_prefix}{start_index + i}"`` where ``i`` is
+        the index of the term.
+
+        Parameters
+        ----------
+        missing_prefix
+            Prefix to use for terms that do not have a name.
+        start_index
+            Index to start from when creating default names.
+
+        Returns
+        -------
+        list of str
+            Term names.
+        """
+        return self.mat.get_term_names(missing_prefix, start_index)

--- a/tests/test_matrices.py
+++ b/tests/test_matrices.py
@@ -621,6 +621,7 @@ def test_split_matrix_creation(mat):
     assert sm.shape[1] == 2 * mat.shape[1]
 
 
+@pytest.mark.parametrize("mat", get_matrices())
 def test_multiply(mat):
     other = np.arange(mat.shape[0])
     expected = mat.A * other[:, np.newaxis]

--- a/tests/test_matrices.py
+++ b/tests/test_matrices.py
@@ -621,7 +621,6 @@ def test_split_matrix_creation(mat):
     assert sm.shape[1] == 2 * mat.shape[1]
 
 
-@pytest.mark.parametrize("mat", get_matrices())
 def test_multiply(mat):
     other = np.arange(mat.shape[0])
     expected = mat.A * other[:, np.newaxis]
@@ -661,3 +660,184 @@ def test_hstack(mat_1, mat_2):
         stacked.A,
         np.hstack([mat.A if not isinstance(mat, np.ndarray) else mat for mat in mats]),
     )
+def test_names_against_expectation():
+    X = tm.DenseMatrix(
+        np.ones((5, 2)), column_names=["a", None], term_names=["a", None]
+    )
+    Xc = tm.CategoricalMatrix(
+        pd.Categorical(["a", "b", "c", "b", "a"]), column_name="c", term_name="c"
+    )
+    Xc2 = tm.CategoricalMatrix(pd.Categorical(["a", "b", "c", "b", "a"]))
+    Xs = tm.SparseMatrix(
+        sps.csc_matrix(np.ones((5, 2))),
+        column_names=["s1", "s2"],
+        term_names=["s", "s"],
+    )
+
+    mat = tm.SplitMatrix(matrices=[X, Xc, Xc2, Xs])
+
+    assert mat.get_names(type="column") == [
+        "a",
+        None,
+        "c[a]",
+        "c[b]",
+        "c[c]",
+        None,
+        None,
+        None,
+        "s1",
+        "s2",
+    ]
+
+    assert mat.get_names(type="term") == [
+        "a",
+        None,
+        "c",
+        "c",
+        "c",
+        None,
+        None,
+        None,
+        "s",
+        "s",
+    ]
+
+    assert mat.get_names(type="column", missing_prefix="_col_") == [
+        "a",
+        "_col_1",
+        "c[a]",
+        "c[b]",
+        "c[c]",
+        "_col_5-7[a]",
+        "_col_5-7[b]",
+        "_col_5-7[c]",
+        "s1",
+        "s2",
+    ]
+
+    assert mat.get_names(type="term", missing_prefix="_col_") == [
+        "a",
+        "_col_1",
+        "c",
+        "c",
+        "c",
+        "_col_5-7",
+        "_col_5-7",
+        "_col_5-7",
+        "s",
+        "s",
+    ]
+
+
+@pytest.mark.parametrize("mat", get_matrices())
+@pytest.mark.parametrize("missing_prefix", ["_col_", "X"])
+def test_names_getter_setter(mat, missing_prefix):
+    names = mat.get_names(missing_prefix=missing_prefix, type="column")
+    mat.column_names = names
+    assert mat.column_names == names
+
+
+@pytest.mark.parametrize("mat", get_matrices())
+@pytest.mark.parametrize("missing_prefix", ["_col_", "X"])
+def test_terms_getter_setter(mat, missing_prefix):
+    names = mat.get_names(missing_prefix=missing_prefix, type="term")
+    mat.term_names = names
+    assert mat.term_names == names
+
+
+@pytest.mark.parametrize("indexer_1", [slice(None, None), 0, slice(2, 8)])
+@pytest.mark.parametrize("indexer_2", [[0], slice(1, 4), [0, 2, 3], [4, 3, 2, 1, 0]])
+@pytest.mark.parametrize("sparse", [True, False])
+def test_names_indexing(indexer_1, indexer_2, sparse):
+    X = np.ones((10, 5), dtype=np.float64)
+    colnames = ["a", "b", None, "d", "e"]
+    termnames = ["t1", "t1", None, "t4", "t5"]
+
+    colnames_array = np.array(colnames)
+    termnames_array = np.array(termnames)
+
+    if sparse:
+        X = tm.SparseMatrix(
+            sps.csc_matrix(X), column_names=colnames, term_names=termnames
+        )
+    else:
+        X = tm.DenseMatrix(X, column_names=colnames, term_names=termnames)
+
+    X_indexed = X[indexer_1, indexer_2]
+    if not isinstance(X_indexed, tm.MatrixBase):
+        pytest.skip("Does not return MatrixBase")
+    assert X_indexed.column_names == list(colnames_array[indexer_2])
+    assert X_indexed.term_names == list(termnames_array[indexer_2])
+
+
+@pytest.mark.parametrize("mat_1", get_all_matrix_base_subclass_mats())
+@pytest.mark.parametrize("mat_2", get_all_matrix_base_subclass_mats())
+def test_combine_names(mat_1, mat_2):
+    mat_1.column_names = mat_1.get_names(missing_prefix="m1_", type="column")
+    mat_2.column_names = mat_2.get_names(missing_prefix="m2_", type="column")
+
+    mat_1.term_names = mat_1.get_names(missing_prefix="m1_", type="term")
+    mat_2.term_names = mat_2.get_names(missing_prefix="m2_", type="term")
+
+    combined = tm.SplitMatrix(matrices=[mat_1, mat_2])
+
+    assert combined.column_names == mat_1.column_names + mat_2.column_names
+    assert combined.term_names == mat_1.term_names + mat_2.term_names
+
+
+@pytest.mark.parametrize("prefix_sep", ["_", ": "])
+@pytest.mark.parametrize("drop_first", [True, False])
+def test_names_pandas(prefix_sep, drop_first):
+    n_rows = 50
+    dense_column = np.linspace(-10, 10, num=n_rows, dtype=np.float64)
+    dense_column_with_lots_of_zeros = dense_column.copy()
+    dense_column_with_lots_of_zeros[:44] = 0.0
+    sparse_column = np.zeros(n_rows, dtype=np.float64)
+    sparse_column[0] = 1.0
+    cat_column_lowdim = np.tile(["a", "b"], n_rows // 2)
+    cat_column_highdim = np.arange(n_rows)
+
+    dense_ser = pd.Series(dense_column)
+    lowdense_ser = pd.Series(dense_column_with_lots_of_zeros)
+    sparse_ser = pd.Series(sparse_column, dtype=pd.SparseDtype("float", 0.0))
+    cat_ser_lowdim = pd.Categorical(cat_column_lowdim)
+    cat_ser_highdim = pd.Categorical(cat_column_highdim)
+
+    df = pd.DataFrame(
+        data={
+            "d": dense_ser,
+            "cl_obj": cat_ser_lowdim.astype(object),
+            "ch": cat_ser_highdim,
+            "ds": lowdense_ser,
+            "s": sparse_ser,
+        }
+    )
+
+    categorical_format = "{name}" + prefix_sep + "{category}"
+    mat_end = tm.from_pandas(
+        df,
+        dtype=np.float64,
+        sparse_threshold=0.3,
+        cat_threshold=4,
+        object_as_cat=True,
+        cat_position="end",
+        categorical_format=categorical_format,
+        drop_first=drop_first,
+    )
+
+    expanded_df = pd.get_dummies(df, prefix_sep=prefix_sep, drop_first=drop_first)
+    assert mat_end.column_names == expanded_df.columns.tolist()
+
+    mat_expand = tm.from_pandas(
+        df,
+        dtype=np.float64,
+        sparse_threshold=0.3,
+        cat_threshold=4,
+        object_as_cat=True,
+        cat_position="expand",
+        categorical_format=categorical_format,
+        drop_first=drop_first,
+    )
+
+    unique_terms = list(dict.fromkeys(mat_expand.term_names))
+    assert unique_terms == df.columns.tolist()


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a `CHANGELOG.rst` entry

## Summary

Add column names and term names metadata to all matrix classes, accessible via the `column_names` and `term_names` properties, or via the `get_names` and `set_names` functions.

## Details

The main idea is that **only DenseMatrix, SparsMatrix and CategoricalMatrix instances have these attributes**, and other types construct theirs on the fly. This reduces complexity and the amount of cases we have to consider. Please see details in comments.

**Column and terms:-** I propose to store store two attributes: column and term names. While it may seem weird from a dataframe perspective, it makes sense when used in a regression setting, especially with a formula interface. A term is an element of a formula (e.g. poly(x) or C(x), while columns are the set of variables they imply. In the case of categoricals, a term is a categorical and a column is one of its dummy columns.

**Names are  optional:** Each name is stored as a vector, can contain None as their elements. When using the column name getter function, those columns will have some dynamically generated name signifying column index (e.g. _col_1 ). These names are not persistent over e.g. matrix concatenation or column reordering. Normal name are.

**Matrix operations:** column names are propagated when concatenating via SplitMatrix or using column indexing.

**Formula interface:** this way of implementing column and term names would streamline the formula materializer a significantly, and a couple hundred lines worth of overloaded functions could be removed.

## Issues

The propagation of these new attributes when using certain methods is inconsistent at best and somewhat incorrect at worst. This inconsistency arises from the fact that dense and sparse matrices are subclassed differently from their respective base classes. 