### PR TITLE
Use boa to build conda packages

### DIFF
--- a/.github/workflows/conda-build-win.yml
+++ b/.github/workflows/conda-build-win.yml
@@ -30,5 +30,5 @@ jobs:
       - name: Build conda package
         shell: pwsh
         run: |
-          mamba install -n base -y conda-build
-          conda build -m .ci_support/${{ matrix.CONDA_BUILD_YML }}.yaml conda.recipe
+          mamba install -n base -y conda-build boa
+          conda mambabuild -m .ci_support/${{ matrix.CONDA_BUILD_YML }}.yaml conda.recipe

--- a/.github/workflows/macos-conda-build.sh
+++ b/.github/workflows/macos-conda-build.sh
@@ -2,7 +2,7 @@
 
 set -exo pipefail
 
-mamba install -y conda-build
+mamba install -y conda-build boa
 
 # Don't test cross-compiled result (there is no emulation) and use the latest MacOS SDK.
 if grep -q "osx-arm64" .ci_support/${CONDA_BUILD_YML}.yaml; then
@@ -13,4 +13,4 @@ CONDA_BUILD_SYSROOT:
  - "${CONDA_BUILD_SYSROOT}"
 EOF
 fi
-conda build -m .ci_support/${CONDA_BUILD_YML}.yaml conda.recipe ${CONDA_BUILD_ARGS:-}
+conda mambabuild -m .ci_support/${CONDA_BUILD_YML}.yaml conda.recipe ${CONDA_BUILD_ARGS:-}


### PR DESCRIPTION
Also for Windows and macOS. Previously, we only used boa on linux.