### PR TITLE
Correctly create missing category from `model_spec`

### DIFF
--- a/src/tabmat/formula.py
+++ b/src/tabmat/formula.py
@@ -425,6 +425,7 @@ class _InteractableCategoricalVector(_InteractableVector):
         reduced_rank: bool,
         missing_method: str = "fail",
         missing_name: str = "(MISSING)",
+        force_convert: bool = False,
     ) -> "_InteractableCategoricalVector":
         """Create an interactable categorical vector from a pandas categorical."""
         categories = list(cat.categories)
@@ -441,7 +442,7 @@ class _InteractableCategoricalVector(_InteractableVector):
                 "if [cat_]missing_method='fail'."
             )
 
-        if missing_method == "convert" and -1 in codes:
+        if missing_method == "convert" and (-1 in codes or force_convert):
             codes[codes == -1] = len(categories)
             categories.append(missing_name)
 
@@ -718,14 +719,17 @@ def encode_contrasts(
             order to avoid spanning the intercept.
     """
     levels = levels if levels is not None else _state.get("categories")
+    force_convert = _state.get("force_convert", False)
     cat = pandas.Categorical(data._values, categories=levels)
     _state["categories"] = cat.categories
+    _state["force_convert"] = missing_method == "convert" and cat.isna().any()
 
     return _InteractableCategoricalVector.from_categorical(
         cat,
         reduced_rank=reduced_rank,
         missing_method=missing_method,
         missing_name=missing_name,
+        force_convert=force_convert,
     )
 
 

--- a/tests/test_formula.py
+++ b/tests/test_formula.py
@@ -690,6 +690,10 @@ def test_cat_missing_C():
 
     assert result.column_names == expected_names
     assert result.model_spec.get_model_matrix(df).column_names == expected_names
+    np.testing.assert_equal(result.model_spec.get_model_matrix(df).A, result.A)
+    np.testing.assert_equal(
+        result.model_spec.get_model_matrix(df[:2]).A, result.A[:2, :]
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a `CHANGELOG.rst` entry

There was a subtle bug in formulas with `missing_method='convert'`. When there is a missing category in the 'training' dataframe (i.e. the one `tm.from_formula` is called on), but there is no missing category in the prediction dataframe (i.e. the one `X.model_spec.get_model_matrix` is called on), then the missing category was not created for the latter and incorrect results were returned. This PR fixes this bug by making `_encode_contrasts` keep track of whether there was a missing value at 'training' time.