### PR TITLE
Revert to conda wheel build

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -21,9 +21,6 @@ jobs:
         uses: docker/setup-qemu-action@v3
         with:
           platforms: all
-
-      - name: Set up micromamba
-        uses: mamba-org/setup-micromamba@2b72821d5ad7f6da3c003a3684ce341bf187b46f
       
       - name: Build wheels
         if: github.event_name != 'release'

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -1,6 +1,7 @@
 name: Build and upload to PyPI
 
 on:
+  push:
   pull_request:
   release:
     types:

--- a/build_tools/prepare_macos_wheel.sh
+++ b/build_tools/prepare_macos_wheel.sh
@@ -8,4 +8,4 @@ else
     CONDA_CHANNEL="conda-forge/osx-64"
 fi
 
-/Users/runner/micromamba-bin/micromamba create -y -p $CONDA/envs/build -c $CONDA_CHANNEL jemalloc-local xsimd llvm-openmp
+conda create -y -n build -c $CONDA_CHANNEL jemalloc-local xsimd llvm-openmp


### PR DESCRIPTION
This PR needs some background information. 
The wheels for macos-arm64 had been broken prior to the 3.1.11 release. #290 fixed the problem, but #294 seemed to have broken it again. The problem can be seen from the delocate (wheel repair) part of cibuildwheel. We need to link three dynamic libraries (libc++, jemalloc, and libomp). With #294, introducing micromamba in the build of the wheel, jemalloc has not been packaged with the wheel anymore.

To be honest, I'm not exactly sure what makes micromamba different from conda. 

Here's where we can find the difference: https://github.com/Quantco/tabmat/actions/runs/6514998408/job/17696892050#step:4:684

You can see that we were missing one library before (this is from the last 3.1.11 release):
https://github.com/Quantco/tabmat/actions/runs/6511122493/job/17686217662#step:6:523

@xhochy, if you know why micromamba is acting this way and how we can fix it, I'm happy to close this PR and fix the problem differently.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a `CHANGELOG.rst` entry
