### PR TITLE
Update mirror for nightlies

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -28,7 +28,7 @@ jobs:
         if: matrix.NOTE == 'Nightly Builds'
         shell: bash -el {0}
         run: |
-          PRE_WHEELS="https://pypi.anaconda.org/scipy-wheels-nightly/simple"
+          PRE_WHEELS="https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/"
           for pkg in numpy pandas scipy; do
             echo "Installing $pkg nightly"
             micromamba remove -y --force $pkg


### PR DESCRIPTION
[scientific-python-nightly-wheels](https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/) is a lot more up to date than [scipy-wheels-nightly](https://pypi.anaconda.org/scipy-wheels-nightly/simple/scikit-learn/).