### PR TITLE
Fix xsimd issue with ppc64le

### DIFF
--- a/build_tools/prepare_macos_wheel.sh
+++ b/build_tools/prepare_macos_wheel.sh
@@ -8,4 +8,4 @@ else
     export CONDA_SUBDIR="osx-64"
 fi
 
-/Users/runner/micromamba-bin/micromamba create -y -p $CONDA/envs/build -c conda-forge jemalloc-local xsimd llvm-openmp
+/Users/runner/micromamba-bin/micromamba create -y -p $CONDA/envs/build -c conda-forge jemalloc-local "xsimd<11,>12.1" llvm-openmp

--- a/build_tools/prepare_macos_wheel.sh
+++ b/build_tools/prepare_macos_wheel.sh
@@ -8,4 +8,4 @@ else
     export CONDA_SUBDIR="osx-64"
 fi
 
-/Users/runner/micromamba-bin/micromamba create -y -p $CONDA/envs/build -c conda-forge jemalloc-local "xsimd<11,>12.1" llvm-openmp
+/Users/runner/micromamba-bin/micromamba create -y -p $CONDA/envs/build -c conda-forge jemalloc-local "xsimd<11|>12.1" llvm-openmp

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - numpy
     - pip
     - setuptools_scm
-    - xsimd <11
+    - xsimd <11|>12.1
   run:
     - python
     - {{ pin_compatible('numpy') }}

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - numpy
     - pip
     - setuptools_scm
-    - xsimd
+    - xsimd <11
   run:
     - python
     - {{ pin_compatible('numpy') }}

--- a/environment-win.yml
+++ b/environment-win.yml
@@ -23,7 +23,7 @@ dependencies:
   - make
   - mako
   - mkl-include
-  - xsimd
+  - xsimd <11
 
   # documentation dev
   - jupyterlab

--- a/environment-win.yml
+++ b/environment-win.yml
@@ -23,7 +23,7 @@ dependencies:
   - make
   - mako
   - mkl-include
-  - xsimd <11,>12.1
+  - xsimd <11|>12.1
 
   # documentation dev
   - jupyterlab

--- a/environment-win.yml
+++ b/environment-win.yml
@@ -23,7 +23,7 @@ dependencies:
   - make
   - mako
   - mkl-include
-  - xsimd <11, >12.1
+  - xsimd <11,>12.1
 
   # documentation dev
   - jupyterlab

--- a/environment-win.yml
+++ b/environment-win.yml
@@ -23,7 +23,7 @@ dependencies:
   - make
   - mako
   - mkl-include
-  - xsimd <11
+  - xsimd <11, >12.1
 
   # documentation dev
   - jupyterlab

--- a/environment.yml
+++ b/environment.yml
@@ -22,7 +22,7 @@ dependencies:
   - jemalloc-local
   - make
   - mako
-  - xsimd
+  - xsimd <11
 
   # documentation dev
   - jupyterlab

--- a/environment.yml
+++ b/environment.yml
@@ -22,7 +22,7 @@ dependencies:
   - jemalloc-local
   - make
   - mako
-  - xsimd <11, >12.1
+  - xsimd <11,>12.1
 
   # documentation dev
   - jupyterlab

--- a/environment.yml
+++ b/environment.yml
@@ -22,7 +22,7 @@ dependencies:
   - jemalloc-local
   - make
   - mako
-  - xsimd <11
+  - xsimd <11, >12.1
 
   # documentation dev
   - jupyterlab

--- a/environment.yml
+++ b/environment.yml
@@ -22,7 +22,7 @@ dependencies:
   - jemalloc-local
   - make
   - mako
-  - xsimd <11,>12.1
+  - xsimd <11|>12.1
 
   # documentation dev
   - jupyterlab

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,13 +69,13 @@ INCLUDE="C:\\\\Miniconda\\\\Library\\\\include"
 [tool.cibuildwheel.linux]
 before-all = [
   "cd ~/",
-  "git clone --branch 5.2.1 https://github.com/jemalloc/jemalloc.git",
+  "git clone --branch 5.3.0 https://github.com/jemalloc/jemalloc.git",
   "cd jemalloc",
   "./autogen.sh --disable-cxx --with-jemalloc-prefix=local --with-install-suffix=local --disable-tls --disable-initial-exec-tls",
   "make",
   "make install_bin install_include install_lib",
   "cd ~/",
-  "git clone --branch 7.6.0 https://github.com/xtensor-stack/xsimd.git",
+  "git clone --branch 12.1.1 https://github.com/xtensor-stack/xsimd.git",
   "cd xsimd",
   "mkdir build",
   "cd build",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ before-build = [
 ]
 
 [tool.cibuildwheel.macos.environment]
-LDFLAGS="-Wl,-rpath,$CONDA/envs/build/lib -L$CONDA/envs/build/lib"
+LDFLAGS="-Wl,-rpath,$CONDA/envs/build/lib -L$CONDA/envs/build/lib,-headerpad_max_install_names"
 CFLAGS="-I$CONDA/envs/build/include"
 CXXFLAGS="-I$CONDA/envs/build/include"
 CXX="/usr/bin/clang++"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ JE_INSTALL_SUFFIX="local"
 
 [tool.cibuildwheel.windows]
 before-all = [
-  "C:\\Miniconda\\condabin\\conda install -c conda-forge xsimd",
+  "C:\\Miniconda\\condabin\\conda install -c conda-forge 'xsimd<11'",
 ]
 
 [tool.cibuildwheel.windows.environment]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ JE_INSTALL_SUFFIX="local"
 
 [tool.cibuildwheel.windows]
 before-all = [
-  "C:\\Miniconda\\condabin\\conda install -c conda-forge 'xsimd<11'",
+  "C:\\Miniconda\\condabin\\conda install -c conda-forge \"xsimd<11\"",
 ]
 
 [tool.cibuildwheel.windows.environment]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ before-build = [
 ]
 
 [tool.cibuildwheel.macos.environment]
-LDFLAGS="-Wl,-rpath,$CONDA/envs/build/lib -L$CONDA/envs/build/lib,-headerpad_max_install_names"
+LDFLAGS="-Wl,-rpath,$CONDA/envs/build/lib -L$CONDA/envs/build/lib -headerpad_max_install_names"
 CFLAGS="-I$CONDA/envs/build/include"
 CXXFLAGS="-I$CONDA/envs/build/include"
 CXX="/usr/bin/clang++"


### PR DESCRIPTION
xsimd does play along nicely with the ppc64le architecture. This has already been flagged, so we will probably be able to use xsimd>=12.2 once available.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a `CHANGELOG.rst` entry
