### PR TITLE
Raise for unseen categories when materializing from an existing `ModelSpec`

### DIFF
--- a/src/tabmat/formula.py
+++ b/src/tabmat/formula.py
@@ -429,7 +429,7 @@ class _InteractableCategoricalVector(_InteractableVector):
         reduced_rank: bool,
         missing_method: str = "fail",
         missing_name: str = "(MISSING)",
-        force_convert: bool = False,
+        add_category_for_nan: bool = False,
     ) -> "_InteractableCategoricalVector":
         """Create an interactable categorical vector from a pandas categorical."""
         categories = list(cat.categories)
@@ -446,7 +446,7 @@ class _InteractableCategoricalVector(_InteractableVector):
                 "if cat_missing_method='fail'."
             )
 
-        if missing_method == "convert" and (-1 in codes or force_convert):
+        if missing_method == "convert" and (-1 in codes or add_category_for_nan):
             codes[codes == -1] = len(categories)
             categories.append(missing_name)
 
@@ -723,10 +723,15 @@ def encode_contrasts(
             order to avoid spanning the intercept.
     """
     levels = levels if levels is not None else _state.get("categories")
-    force_convert = _state.get("force_convert", False)
+    add_category_for_nan = _state.get("add_category_for_nan", False)
 
+    # Check for unseen categories when levels are specified
     if levels is not None:
-        unseen_categories = set(data.dropna().unique()) - set(levels)
+        if missing_method == "convert" and not add_category_for_nan:
+            unseen_categories = set(data.unique()) - set(levels)
+        else:
+            unseen_categories = set(data.dropna().unique()) - set(levels)
+
         if unseen_categories:
             raise ValueError(
                 f"Column {data.name} contains unseen categories: {unseen_categories}."
@@ -734,14 +739,16 @@ def encode_contrasts(
 
     cat = pandas.Categorical(data._values, categories=levels)
     _state["categories"] = cat.categories
-    _state["force_convert"] = missing_method == "convert" and cat.isna().any()
+    _state["add_category_for_nan"] = add_category_for_nan or (
+        missing_method == "convert" and cat.isna().any()
+    )
 
     return _InteractableCategoricalVector.from_categorical(
         cat,
         reduced_rank=reduced_rank,
         missing_method=missing_method,
         missing_name=missing_name,
-        force_convert=force_convert,
+        add_category_for_nan=add_category_for_nan,
     )
 
 

--- a/src/tabmat/formula.py
+++ b/src/tabmat/formula.py
@@ -726,7 +726,7 @@ def encode_contrasts(
     force_convert = _state.get("force_convert", False)
 
     if levels is not None:
-        unseen_categories = set(data.unique()) - set(levels)
+        unseen_categories = set(data.dropna().unique()) - set(levels)
         if unseen_categories:
             raise ValueError(
                 f"Column {data.name} contains unseen categories: {unseen_categories}."

--- a/src/tabmat/formula.py
+++ b/src/tabmat/formula.py
@@ -728,6 +728,9 @@ def encode_contrasts(
     # Check for unseen categories when levels are specified
     if levels is not None:
         if missing_method == "convert" and not add_missing_category:
+            # We only need to include NAs in the check in this case because:
+            #  - missing_method == "fail" raises a more appropriate error later
+            #  - missings are no problem in the other cases
             unseen_categories = set(data.unique()) - set(levels)
         else:
             unseen_categories = set(data.dropna().unique()) - set(levels)

--- a/src/tabmat/formula.py
+++ b/src/tabmat/formula.py
@@ -429,7 +429,7 @@ class _InteractableCategoricalVector(_InteractableVector):
         reduced_rank: bool,
         missing_method: str = "fail",
         missing_name: str = "(MISSING)",
-        add_category_for_nan: bool = False,
+        add_missing_category: bool = False,
     ) -> "_InteractableCategoricalVector":
         """Create an interactable categorical vector from a pandas categorical."""
         categories = list(cat.categories)
@@ -446,7 +446,7 @@ class _InteractableCategoricalVector(_InteractableVector):
                 "if cat_missing_method='fail'."
             )
 
-        if missing_method == "convert" and (-1 in codes or add_category_for_nan):
+        if missing_method == "convert" and (-1 in codes or add_missing_category):
             codes[codes == -1] = len(categories)
             categories.append(missing_name)
 
@@ -723,11 +723,11 @@ def encode_contrasts(
             order to avoid spanning the intercept.
     """
     levels = levels if levels is not None else _state.get("categories")
-    add_category_for_nan = _state.get("add_category_for_nan", False)
+    add_missing_category = _state.get("add_missing_category", False)
 
     # Check for unseen categories when levels are specified
     if levels is not None:
-        if missing_method == "convert" and not add_category_for_nan:
+        if missing_method == "convert" and not add_missing_category:
             unseen_categories = set(data.unique()) - set(levels)
         else:
             unseen_categories = set(data.dropna().unique()) - set(levels)
@@ -739,7 +739,7 @@ def encode_contrasts(
 
     cat = pandas.Categorical(data._values, categories=levels)
     _state["categories"] = cat.categories
-    _state["add_category_for_nan"] = add_category_for_nan or (
+    _state["add_missing_category"] = add_missing_category or (
         missing_method == "convert" and cat.isna().any()
     )
 
@@ -748,7 +748,7 @@ def encode_contrasts(
         reduced_rank=reduced_rank,
         missing_method=missing_method,
         missing_name=missing_name,
-        add_category_for_nan=add_category_for_nan,
+        add_missing_category=add_missing_category,
     )
 
 

--- a/src/tabmat/formula.py
+++ b/src/tabmat/formula.py
@@ -726,7 +726,7 @@ def encode_contrasts(
     force_convert = _state.get("force_convert", False)
 
     if levels is not None:
-        unseen_categories = set(data._values.unique()) - set(levels)
+        unseen_categories = set(data.unique()) - set(levels)
         if unseen_categories:
             raise ValueError(
                 f"Column {data.name} contains unseen categories: {unseen_categories}."

--- a/src/tabmat/formula.py
+++ b/src/tabmat/formula.py
@@ -724,6 +724,14 @@ def encode_contrasts(
     """
     levels = levels if levels is not None else _state.get("categories")
     force_convert = _state.get("force_convert", False)
+
+    if levels is not None:
+        unseen_categories = set(data._values.unique()) - set(levels)
+        if unseen_categories:
+            raise ValueError(
+                f"Column {data.name} contains unseen categories: {unseen_categories}."
+            )
+
     cat = pandas.Categorical(data._values, categories=levels)
     _state["categories"] = cat.categories
     _state["force_convert"] = missing_method == "convert" and cat.isna().any()

--- a/tests/test_formula.py
+++ b/tests/test_formula.py
@@ -747,7 +747,7 @@ def test_cat_missing_interactions():
 
 
 @pytest.mark.parametrize(
-    "cat_missing_method", ["zero", "convert"], ids=["zero", "convert"]
+    "cat_missing_method", ["zero", "convert", "fail"], ids=["zero", "convert", "fail"]
 )
 def test_unseen_category(cat_missing_method):
     df = pd.DataFrame(
@@ -763,6 +763,23 @@ def test_unseen_category(cat_missing_method):
     result_seen = tm.from_formula(
         "cat_1 - 1", df, cat_missing_method=cat_missing_method
     )
+
+    with pytest.raises(ValueError, match="contains unseen categories"):
+        result_seen.model_spec.get_model_matrix(df_unseen)
+
+
+def test_unseen_missing_convert():
+    df = pd.DataFrame(
+        {
+            "cat_1": pd.Categorical(["a", "b"]),
+        }
+    )
+    df_unseen = pd.DataFrame(
+        {
+            "cat_1": pd.Categorical(["a", "b", pd.NA]),
+        }
+    )
+    result_seen = tm.from_formula("cat_1 - 1", df, cat_missing_method="convert")
 
     with pytest.raises(ValueError, match="contains unseen categories"):
         result_seen.model_spec.get_model_matrix(df_unseen)

--- a/tests/test_formula.py
+++ b/tests/test_formula.py
@@ -746,6 +746,28 @@ def test_cat_missing_interactions():
     assert tm.from_formula(formula, df).column_names == expected_names
 
 
+@pytest.mark.parametrize(
+    "cat_missing_method", ["zero", "convert"], ids=["zero", "convert"]
+)
+def test_unseen_category(cat_missing_method):
+    df = pd.DataFrame(
+        {
+            "cat_1": pd.Categorical(["a", "b"]),
+        }
+    )
+    df_unseen = pd.DataFrame(
+        {
+            "cat_1": pd.Categorical(["a", "b", "c"]),
+        }
+    )
+    result_seen = tm.from_formula(
+        "cat_1 - 1", df, cat_missing_method=cat_missing_method
+    )
+
+    with pytest.raises(ValueError, match="contains unseen categories"):
+        result_seen.model_spec.get_model_matrix(df_unseen)
+
+
 # Tests from formulaic's test suite
 # ---------------------------------
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a `CHANGELOG.rst` entry

Added a check for unseen levels when materializing a matrix from an existing modelspec. This is analogous to raising an error when trying to predict from categoricals having levels unseen in the training data. This error is especially useful for glum, because it solves [glum PR #748](https://github.com/Quantco/glum/pull/748) when glum with formulas.

It also makes tabmat's formula materialization stricter than formulaic's. The latter only emits a warning in this case, and sets all dummies to zero. I think the proposed tabmat behavior also makes sense, especially in conjunction with glum, but let me know if you think otherwise. (Maybe one point for discussion could be what should happen if `cat_missing_method="zero"`. In the proposed PR, unseen categories still raise a `ValueError`, but a warning plus setting all dummies to zero might also make sense in that case. Same question goes for glum's behavior.)
