### PR TITLE
replace `.A` with `.toarray()`

### DIFF
--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -48,13 +48,13 @@ jobs:
         if: matrix.os != 'windows-latest'
         shell: bash -el {0}
         run: >-
-          conda-mambabuild
+          conda-build
           -m ".ci_support/${{ matrix.CONDA_BUILD_YML }}.yaml"${{ matrix.conda-build-args }}
           conda.recipe
       - name: Build conda package (windows)
         if: matrix.os == 'windows-latest'
         shell: cmd /C CALL {0}
         run: >-
-          conda-mambabuild
+          conda-build
           -m ".ci_support/${{ matrix.conda_build_yml }}.yaml"${{ matrix.conda-build-args }}
           conda.recipe

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -48,13 +48,13 @@ jobs:
         if: matrix.os != 'windows-latest'
         shell: bash -el {0}
         run: >-
-          conda-build
+          conda-mambabuild
           -m ".ci_support/${{ matrix.CONDA_BUILD_YML }}.yaml"${{ matrix.conda-build-args }}
           conda.recipe
       - name: Build conda package (windows)
         if: matrix.os == 'windows-latest'
         shell: cmd /C CALL {0}
         run: >-
-          conda-build
+          conda-mambabuild
           -m ".ci_support/${{ matrix.conda_build_yml }}.yaml"${{ matrix.conda-build-args }}
           conda.recipe

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -37,6 +37,8 @@ jobs:
             micromamba remove -y --force $pkg
             pip install --pre --no-deps --only-binary :all: --upgrade --timeout=60 -i $PRE_WHEELS $pkg
           done
+          micromamba remove -y --force formulaic
+          pip install --no-use-pep517 --no-deps git+https://github.com/matthewwardrop/formulaic
           micromamba list
       - name: Install repository
         shell: bash -el {0}

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -38,7 +38,7 @@ jobs:
             pip install --pre --no-deps --only-binary :all: --upgrade --timeout=60 -i $PRE_WHEELS $pkg
           done
           micromamba remove -y --force formulaic
-          pip install --no-use-pep517 --no-deps git+https://github.com/matthewwardrop/formulaic
+          pip install --no-deps git+https://github.com/matthewwardrop/formulaic
           micromamba list
       - name: Install repository
         shell: bash -el {0}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,13 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+**Other changes:**
+
+- Removed reference to the ``.A`` attribute and replaced it with ``.toarray()``.
+
 4.0.0 - 2024-04-23
 ------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Unreleased
 **Other changes:**
 
 - Removed reference to the ``.A`` attribute and replaced it with ``.toarray()``.
+- Add support between formulaic and pandas 3.0
 
 4.0.0 - 2024-04-23
 ------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,11 @@ requires = [
 ]
 
 [tool.ruff]
-ignore = ["E731", "N802", "N803", "N806"]
 line-length = 88
+target-version = "py39"
+
+[tool.ruff.lint]
+ignore = ["E731", "N802", "N803", "N806"]
 select = [
   # pyflakes
   "F",
@@ -23,9 +26,8 @@ select = [
   # pyupgrade
   "UP",
 ]
-target-version = "py39"
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-first-party = ["tabmat"]
 
 [tool.mypy]

--- a/src/tabmat/categorical_matrix.py
+++ b/src/tabmat/categorical_matrix.py
@@ -586,7 +586,7 @@ class CategoricalMatrix(MatrixBase):
 
     def toarray(self) -> np.ndarray:
         """Return array representation of matrix."""
-        return self.tocsr().A
+        return self.tocsr().toarray()
 
     def unpack(self):
         """Return the underlying pandas.Categorical."""
@@ -703,7 +703,7 @@ class CategoricalMatrix(MatrixBase):
 
         term_1 = _row_col_indexing(term_1, rows, L_cols)
 
-        res = term_1.T.dot(_row_col_indexing(other, rows, R_cols)).A
+        res = term_1.T.dot(_row_col_indexing(other, rows, R_cols)).toarray()
         return res
 
     def multiply(self, other) -> SparseMatrix:

--- a/src/tabmat/formula.py
+++ b/src/tabmat/formula.py
@@ -29,7 +29,7 @@ class TabmatMaterializer(FormulaMaterializer):
     """Materializer for pandas input and tabmat output."""
 
     REGISTER_NAME = "tabmat"
-    REGISTER_INPUTS = ("pandas.core.frame.DataFrame",)
+    REGISTER_INPUTS = ("pandas.core.frame.DataFrame", "pandas.DataFrame")
     REGISTER_OUTPUTS = "tabmat"
 
     @override

--- a/src/tabmat/split_matrix.py
+++ b/src/tabmat/split_matrix.py
@@ -306,7 +306,7 @@ class SplitMatrix(MatrixBase):
         """Return array representation of matrix."""
         out = np.empty(self.shape)
         for mat, idx in zip(self.matrices, self.indices):
-            out[:, idx] = mat.A
+            out[:, idx] = mat.toarray()
         return out
 
     def getcol(self, i: int) -> Union[np.ndarray, sps.csr_matrix]:

--- a/src/tabmat/standardized_mat.py
+++ b/src/tabmat/standardized_mat.py
@@ -105,7 +105,7 @@ class StandardizedMatrix:
         >>> col_1 = x.getcol(1)
         >>> isinstance(col_1, StandardizedMatrix)
         True
-        >>> col_1.A
+        >>> col_1.toarray()
         array([[1.],
                [2.],
                [1.]])
@@ -254,7 +254,7 @@ class StandardizedMatrix:
 
     def toarray(self) -> np.ndarray:
         """Return array representation of matrix."""
-        mat_part = self.mat.A
+        mat_part = self.mat.toarray()
         if self.mult is not None:
             mat_part = self.mult[None, :] * mat_part
         return mat_part + self.shift[None, :]
@@ -285,7 +285,7 @@ class StandardizedMatrix:
             mult_part = np.atleast_1d(mult_part[col])
 
         if isinstance(row, int):
-            out = mat_part.A
+            out = mat_part.toarray()
             if mult_part is not None:
                 out = out * mult_part
             return out + shift_part

--- a/tests/test_categorical_matrix.py
+++ b/tests/test_categorical_matrix.py
@@ -65,7 +65,7 @@ def test_csr_matvec_categorical(
     )
     vec = np.random.choice(np.arange(4, dtype=vec_dtype), mat.shape[1])
     res = cat_mat.matvec(vec)
-    np.testing.assert_allclose(res, cat_mat.A.dot(vec))
+    np.testing.assert_allclose(res, cat_mat.toarray().dot(vec))
 
 
 @pytest.mark.parametrize("drop_first", [True, False], ids=["drop_first", "no_drop"])
@@ -84,7 +84,7 @@ def test_tocsr(cat_vec, drop_first, missing, cat_missing_method):
     cat_mat = CategoricalMatrix(
         cat_vec, drop_first=drop_first, cat_missing_method=cat_missing_method
     )
-    res = cat_mat.tocsr().A
+    res = cat_mat.tocsr().toarray()
     expected = pd.get_dummies(
         cat_vec,
         drop_first=drop_first,
@@ -148,7 +148,7 @@ def test_multiply(cat_vec, drop_first, missing, cat_missing_method):
         )
         * other
     )
-    np.testing.assert_allclose(actual.A, expected)
+    np.testing.assert_allclose(actual.toarray(), expected)
 
 
 @pytest.mark.parametrize("mi_element", [np.nan, None])
@@ -202,4 +202,4 @@ def test_categorical_indexing(drop_first, missing, cat_missing_method):
         drop_first=drop_first,
         dummy_na=cat_missing_method == "convert" and missing,
     ).to_numpy()[:, [0, 1]]
-    np.testing.assert_allclose(mat[:, [0, 1]].A, expected)
+    np.testing.assert_allclose(mat[:, [0, 1]].toarray(), expected)

--- a/tests/test_mkl_sparse_matrix.py
+++ b/tests/test_mkl_sparse_matrix.py
@@ -14,15 +14,15 @@ def x() -> sps.csc_matrix:
 def test_mkl_sparse_init(x: sps.csc_matrix):
     one = SparseMatrix(x)
     two = SparseMatrix((x.data, x.indices, x.indptr), shape=x.shape)
-    three = SparseMatrix(x.A)
-    np.testing.assert_allclose(one.A, two.A)
-    np.testing.assert_allclose(one.A, three.A)
+    three = SparseMatrix(x.toarray())
+    np.testing.assert_allclose(one.toarray(), two.toarray())
+    np.testing.assert_allclose(one.toarray(), three.toarray())
 
 
 def test_to_csc(x: sps.csc_matrix):
     one = SparseMatrix(x).tocsc()
     two = SparseMatrix((x.data, x.indices, x.indptr), shape=x.shape).tocsc()
-    three = SparseMatrix(x.A).tocsc()
+    three = SparseMatrix(x.toarray()).tocsc()
 
     assert isinstance(one, sps.csc_matrix)
     assert isinstance(two, sps.csc_matrix)

--- a/tests/test_split_matrix.py
+++ b/tests/test_split_matrix.py
@@ -132,9 +132,9 @@ def test_init(mat: SplitMatrix):
     ],
 )
 def test_init_from_split(mat):
-    np.testing.assert_array_equal(mat.A, tm.SplitMatrix([mat]).A)
+    np.testing.assert_array_equal(mat.toarray(), tm.SplitMatrix([mat]).toarray())
     np.testing.assert_array_equal(
-        np.hstack([mat.A, mat.A]), tm.SplitMatrix([mat, mat]).A
+        np.hstack([mat.toarray(), mat.toarray()]), tm.SplitMatrix([mat, mat]).toarray()
     )
 
 
@@ -162,7 +162,7 @@ def test_sandwich_sparse_dense(X: np.ndarray, Acols, Bcols):
     A = sps.random(n, 2).tocsr()
     rows = np.arange(d.shape[0], dtype=np.int32)
     result = csr_dense_sandwich(A, X, d, rows, Acols, Bcols)
-    expected = A.T.A[Acols, :] @ np.diag(d) @ X[:, Bcols]
+    expected = A.T.toarray()[Acols, :] @ np.diag(d) @ X[:, Bcols]
     np.testing.assert_allclose(result, expected)
 
 
@@ -184,7 +184,7 @@ def test_sandwich(mat: tm.SplitMatrix, cols):
     for _ in range(10):
         v = np.random.rand(mat.shape[0])
         y1 = mat.sandwich(v, cols=cols)
-        mat_limited = mat.A if cols is None else mat.A[:, cols]
+        mat_limited = mat.toarray() if cols is None else mat.toarray()[:, cols]
         y2 = (mat_limited.T * v[None, :]) @ mat_limited
         np.testing.assert_allclose(y1, y2, atol=1e-12)
 
@@ -260,7 +260,7 @@ def test_sandwich_many_types(missing):
     def check(mat):
         d = np.random.random(mat.shape[0])
         res = mat.sandwich(d)
-        expected = (mat.A.T * d[None, :]) @ mat.A
+        expected = (mat.toarray().T * d[None, :]) @ mat.toarray()
         np.testing.assert_allclose(res, expected)
 
     many_random_tests(check, missing)
@@ -271,7 +271,7 @@ def test_transpose_matvec_many_types(missing):
     def check(mat):
         d = np.random.random(mat.shape[0])
         res = mat.transpose_matvec(d)
-        expected = mat.A.T.dot(d)
+        expected = mat.toarray().T.dot(d)
         np.testing.assert_almost_equal(res, expected)
 
     many_random_tests(check, missing)
@@ -282,7 +282,7 @@ def test_matvec_many_types(missing):
     def check(mat):
         d = np.random.random(mat.shape[1])
         res = mat.matvec(d)
-        expected = mat.A.dot(d)
+        expected = mat.toarray().dot(d)
         np.testing.assert_almost_equal(res, expected)
 
     many_random_tests(check, missing)

--- a/tests/test_standardized_mat.py
+++ b/tests/test_standardized_mat.py
@@ -12,13 +12,13 @@ n_cols = 5
 sp_mat = tm.SparseMatrix(sps.random(n_rows, n_cols, density=0.8))
 col_shift = np.random.uniform(0, 1, n_cols)
 col_mult = np.random.uniform(0.5, 1.5, n_cols)
-expected_mat = col_mult[None, :] * sp_mat.A + col_shift[None, :]
+expected_mat = col_mult[None, :] * sp_mat.toarray() + col_shift[None, :]
 standardized_mat = tm.StandardizedMatrix(sp_mat, col_shift, col_mult)
 
 
 def test_setup_and_densify_col():
-    assert standardized_mat.A.shape == (n_rows, n_cols)
-    np.testing.assert_almost_equal(standardized_mat.A, expected_mat)
+    assert standardized_mat.toarray().shape == (n_rows, n_cols)
+    np.testing.assert_almost_equal(standardized_mat.toarray(), expected_mat)
 
 
 def test_standardized_matvec():


### PR DESCRIPTION
<!-- ⚠️ This is an open-source repository. Do not share sensitive information. -->

This is causing a failure in glum. The `.A` attribute has been deprecated since v1.11 of scipy and is removed in the upcoming v1.14.
I have also fixed the formulaic error in the nightly build.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a `CHANGELOG.rst` entry
