### PR TITLE
Bump windows builds to vs2019

### DIFF
--- a/.ci_support/win_64_python3.10.____cpython.yaml
+++ b/.ci_support/win_64_python3.10.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
-- vs2017
+- vs2019
 cxx_compiler:
-- vs2017
+- vs2019
 numpy:
 - '1.22'
 python:

--- a/.ci_support/win_64_python3.12.____cpython.yaml
+++ b/.ci_support/win_64_python3.12.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
-- vs2017
+- vs2019
 cxx_compiler:
-- vs2017
+- vs2019
 numpy:
 - '1.26'
 python:

--- a/.ci_support/win_64_python3.9.____cpython.yaml
+++ b/.ci_support/win_64_python3.9.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
-- vs2017
+- vs2019
 cxx_compiler:
-- vs2017
+- vs2019
 numpy:
 - '1.22'
 python:


### PR DESCRIPTION
MS removed the old compiler toolchain, let's move forward as conda-forge also did.
