### PR TITLE
Fix numpy 2.0 build error

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-11]
+        os: [ubuntu-20.04, windows-2019, macos-12]
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Unreleased
 
 - Removed reference to the ``.A`` attribute and replaced it with ``.toarray()``.
 - Add support between formulaic and pandas 3.0
+- Support pypi release for numpy 2.0
 
 4.0.0 - 2024-04-23
 ------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
   'setuptools-scm', 
   'wheel',
   'mako',
-  'oldest-supported-numpy',
+  'numpy',
   'Cython != 3.0.4',
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
   'setuptools-scm', 
   'wheel',
   'mako',
-  'numpy',
+  'numpy>=1.25',
   'Cython != 3.0.4',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -157,7 +157,7 @@ setup(
     ],
     package_dir={"": "src"},
     packages=find_packages(where="src"),
-    install_requires=["numpy=1.23", "pandas", "scipy", "formulaic>=0.6"],
+    install_requires=["numpy>=1.23,<1.24", "pandas", "scipy", "formulaic>=0.6"],
     python_requires=">=3.9",
     ext_modules=cythonize(
         ext_modules,

--- a/setup.py
+++ b/setup.py
@@ -157,7 +157,7 @@ setup(
     ],
     package_dir={"": "src"},
     packages=find_packages(where="src"),
-    install_requires=["numpy", "pandas", "scipy", "formulaic>=0.6"],
+    install_requires=["numpy=1.23", "pandas", "scipy", "formulaic>=0.6"],
     python_requires=">=3.9",
     ext_modules=cythonize(
         ext_modules,

--- a/setup.py
+++ b/setup.py
@@ -157,7 +157,7 @@ setup(
     ],
     package_dir={"": "src"},
     packages=find_packages(where="src"),
-    install_requires=["numpy>=1.23,<1.24", "pandas", "scipy", "formulaic>=0.6"],
+    install_requires=["numpy", "pandas", "scipy", "formulaic>=0.6"],
     python_requires=">=3.9",
     ext_modules=cythonize(
         ext_modules,

--- a/src/tabmat/ext/categorical.pyx
+++ b/src/tabmat/ext/categorical.pyx
@@ -1,7 +1,7 @@
 import numpy as np
 
 cimport numpy as np
-from cython cimport floating, numeric
+from cython cimport floating
 
 from cython.parallel import prange
 
@@ -217,7 +217,7 @@ def sandwich_categorical_complex(
 
 def multiply_complex(
     int[:] indices,
-    numeric[:] d,
+    floating[:] d,
     int ncols,
     dtype,
     bint drop_first,
@@ -252,7 +252,7 @@ def multiply_complex(
         np.ndarray new_data = np.empty(nrows, dtype=dtype)
         np.ndarray new_indices = np.empty(nrows, dtype=np.int32)
         np.ndarray new_indptr = np.empty(nrows + 1, dtype=np.int32)
-        numeric[:] vnew_data = new_data
+        floating[:] vnew_data = new_data
         int[:] vnew_indices = new_indices
         int[:] vnew_indptr = new_indptr
 

--- a/src/tabmat/ext/categorical.pyx
+++ b/src/tabmat/ext/categorical.pyx
@@ -1,7 +1,7 @@
 import numpy as np
 
 cimport numpy as np
-from cython cimport floating
+from cython cimport floating, numeric
 
 from cython.parallel import prange
 
@@ -11,6 +11,9 @@ from libcpp cimport bool
 
 np.import_array()
 
+ctypedef fused win_numeric:
+    numeric
+    long long
 
 cdef extern from "cat_split_helpers.cpp":
     void _transpose_matvec_all_rows_fast[Int, F](Int, Int*, F*, F*, Int)
@@ -217,7 +220,7 @@ def sandwich_categorical_complex(
 
 def multiply_complex(
     int[:] indices,
-    floating[:] d,
+    win_numeric[:] d,
     int ncols,
     dtype,
     bint drop_first,
@@ -252,7 +255,7 @@ def multiply_complex(
         np.ndarray new_data = np.empty(nrows, dtype=dtype)
         np.ndarray new_indices = np.empty(nrows, dtype=np.int32)
         np.ndarray new_indptr = np.empty(nrows + 1, dtype=np.int32)
-        floating[:] vnew_data = new_data
+        win_numeric[:] vnew_data = new_data
         int[:] vnew_indices = new_indices
         int[:] vnew_indptr = new_indptr
 

--- a/src/tabmat/ext/categorical.pyx
+++ b/src/tabmat/ext/categorical.pyx
@@ -9,6 +9,8 @@ ctypedef np.uint8_t uint8
 ctypedef np.int8_t int8
 from libcpp cimport bool
 
+np.import_array()
+
 
 cdef extern from "cat_split_helpers.cpp":
     void _transpose_matvec_all_rows_fast[Int, F](Int, Int*, F*, F*, Int)

--- a/src/tabmat/ext/dense.pyx
+++ b/src/tabmat/ext/dense.pyx
@@ -5,6 +5,9 @@ from cython cimport floating
 from cython.parallel import prange
 from libc.stdint cimport int64_t
 
+np.import_array()
+
+
 cdef extern from "dense_helpers.cpp":
     void _denseC_sandwich[Int, F](Int*, Int*, F*, F*, F*, Int, Int, Int, Int, Int, Int, Int) nogil
     void _denseF_sandwich[Int, F](Int*, Int*, F*, F*, F*, Int, Int, Int, Int, Int, Int, Int) nogil

--- a/src/tabmat/ext/sparse.pyx
+++ b/src/tabmat/ext/sparse.pyx
@@ -5,6 +5,9 @@ from cython cimport floating, integral
 from cython.parallel import prange
 from libc.stdint cimport int64_t
 
+
+np.import_array()
+
 ctypedef np.uint8_t uint8
 
 ctypedef fused win_integral:


### PR DESCRIPTION
Couple of changes from this PR:

- explicit numpy array import. This makes the error message more clear.
- replace "oldest-supported-numpy" with simply "numpy". We should probably make sure that this does not make it incompatible with older version of numpy.
- switch to macos-12 to built the macos wheel.
- add long long to numeric fused type. This probably has something to do with this new numpy feature from the 2.0 release: "The default integer type on Windows is now int64 rather than int32, matching the behavior on other platforms".

<!-- ⚠️ This is an open-source repository. Do not share sensitive information. -->

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a `CHANGELOG.rst` entry


Still to do:
* [x] Verify that the new build works with older versions of numpy
