### PR TITLE
Update nightly tests

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -21,10 +21,8 @@ jobs:
         uses: docker/setup-qemu-action@v3
         with:
           platforms: all
-
       - name: Set up micromamba
         uses: mamba-org/setup-micromamba@f8b8a1e23a26f60a44c853292711bacfd3eac822
-      
       - name: Build wheels
         if: github.event_name != 'release'
         uses: pypa/cibuildwheel@v2.19.1
@@ -32,7 +30,6 @@ jobs:
           CIBW_ARCHS_LINUX: auto
           CIBW_ARCHS_MACOS: x86_64 arm64
           CIBW_TEST_SKIP: '*-macosx_arm64'
-      
       - name: Build wheels (release)
         if: github.event_name == 'release' && github.event.action == 'published'
         uses: pypa/cibuildwheel@v2.19.1
@@ -50,18 +47,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
       - uses: actions/setup-python@v5
         name: Install Python
         with:
           python-version: '3.10'
-
       - name: Install build dependencies
-        run: python -m pip install setuptools setuptools-scm wheel mako numpy 'Cython!=3.0.4' 
-
+        run: python -m pip install setuptools setuptools-scm wheel mako numpy 'Cython!=3.0.4'
       - name: Build sdist
         run: python setup.py sdist
-
       - uses: actions/upload-artifact@v4
         with:
           path: dist/*.tar.gz
@@ -70,7 +63,7 @@ jobs:
     if: github.event_name == 'release' && github.event.action == 'published'
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
-    environment: 
+    environment:
       name: release
       url: https://test.pypi.org/p/tabmat
     permissions:
@@ -80,7 +73,6 @@ jobs:
         with:
           merge-multiple: true
           path: dist
-
       - uses: pypa/gh-action-pypi-publish@v1.9.0
         with:
           repository-url: https://test.pypi.org/legacy/
@@ -89,7 +81,7 @@ jobs:
     if: github.event_name == 'release' && github.event.action == 'published'
     needs: [build_wheels, build_sdist, upload_testpypi]
     runs-on: ubuntu-latest
-    environment: 
+    environment:
       name: release
       url: https://pypi.org/p/tabmat
     permissions:
@@ -99,5 +91,4 @@ jobs:
         with:
           merge-multiple: true
           path: dist
-
       - uses: pypa/gh-action-pypi-publish@v1.9.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,18 +23,19 @@ jobs:
         uses: pre-commit/action@v3.0.1
 
   unit-tests:
-    name: Tests - ${{ matrix.os }} - Py${{ matrix.python-version }}
+    name: Tests - ${{ matrix.os }} - Py${{ matrix.python-version }} - ${{ matrix.note }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true
       matrix:
         include:
-          - { os: ubuntu-latest, python-version: '3.9' }
-          - { os: ubuntu-latest, python-version: '3.10' }
-          - { os: ubuntu-latest, python-version: '3.11' }
-          - { os: ubuntu-latest, python-version: '3.12' }
-          - { os: macos-latest, python-version: '3.12' }
-          - { os: windows-latest, python-version: '3.12' }
+          - { os: ubuntu-latest,  python-version: '3.9',  note: 'Default Builds' }
+          - { os: ubuntu-latest,  python-version: '3.10', note: 'Default Builds' }
+          - { os: ubuntu-latest,  python-version: '3.11', note: 'Default Builds' }
+          - { os: ubuntu-latest,  python-version: '3.12', note: 'Default Builds' }
+          - { os: ubuntu-latest,  python-version: '3.12', note: 'Nightly Builds' }
+          - { os: macos-latest,   python-version: '3.12', note: 'Default Builds' }
+          - { os: windows-latest, python-version: '3.12', note: 'Default Builds' }
     steps:
       - name: Checkout branch
         uses: actions/checkout@v4
@@ -46,6 +47,19 @@ jobs:
           cache-environment: true
           create-args: >-
             python=${{ matrix.python-version }}
+      - name: Install nightlies
+        if: matrix.note == 'Nightly Builds'
+        shell: bash -el {0}
+        run: |
+          PRE_WHEELS="https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/"
+          for pkg in numpy pandas scipy; do
+            echo "Installing $pkg nightly"
+            micromamba remove -y --force $pkg
+            pip install --pre --no-deps --only-binary :all: --upgrade --timeout=60 -i $PRE_WHEELS $pkg
+          done
+          micromamba remove -y --force formulaic
+          pip install --no-deps git+https://github.com/matthewwardrop/formulaic
+          micromamba list
       - name: Install repository (unix)
         if: matrix.os != 'windows-latest'
         shell: bash -el {0}

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -19,7 +19,7 @@ jobs:
           - { conda_build_yml: linux_64_python3.12_default.____cpython,      os: ubuntu-latest,  conda-build-args: '' }
           - { conda_build_yml: linux_aarch64_python3.10_default.____cpython, os: ubuntu-latest,  conda-build-args: ' --no-test' }
           - { conda_build_yml: linux_ppc64le_python3.10_default.____cpython, os: ubuntu-latest,  conda-build-args: ' --no-test' }
-          - { conda_build_yml: osx_64_python3.11_default.____cpython,         os: macos-latest,   conda-build-args: '' }
+          - { conda_build_yml: osx_64_python3.11_default.____cpython,        os: macos-latest,   conda-build-args: '' }
           - { conda_build_yml: osx_arm64_python3.9.____cpython,              os: macos-latest,   conda-build-args: ' --no-test' }
           - { conda_build_yml: osx_arm64_python3.10.____cpython,             os: macos-latest,   conda-build-args: ' --no-test' }
           - { conda_build_yml: win_64_python3.9.____cpython,                 os: windows-latest, conda-build-args: '' }

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -9,16 +9,14 @@ on:
 
 jobs:
   linux-daily-unittests:
-    name: "Linux - daily unit tests - Python ${{ matrix.PYTHON_VERSION }} - ${{ matrix.NOTE }}"
+    name: Daily unit tests - Py${{ matrix.python-version }} - ${{ matrix.note }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         include:
-          - PYTHON_VERSION: '3.9'
-            NOTE: 'Nightly Builds' # run once with nightlies
-          - PYTHON_VERSION: '3.9'
-            NOTE: 'Default Builds' # run once with normal dependencies
+          - { python-version: '3.9',  note: 'Default Builds' }
+          - { python-version: '3.12', note: 'Nightly Builds' }
     steps:
       - name: Checkout branch
         uses: actions/checkout@v4
@@ -26,9 +24,9 @@ jobs:
         with:
           environment-file: environment.yml
           create-args: >-
-            python=${{ matrix.PYTHON_VERSION }}
+            python=${{ matrix.python-version }}
       - name: Install nightlies
-        if: matrix.NOTE == 'Nightly Builds'
+        if: matrix.note == 'Nightly Builds'
         shell: bash -el {0}
         run: |
           PRE_WHEELS="https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/"


### PR DESCRIPTION
- Use Python 3.12 in the daily run with nightly versions.
- Add a run with nightly versions to CI.

Closes #373.