### PR TITLE
Fix bug due to precision in CategoricalMatrix._get_col_stds

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Changelog
 
 - Added a new function, :func:`tabmat.from_polars`, to convert a :class:`polars.DataFrame` into a :class:`tabmat.SplitMatrix`.
 
+**Bug fix:**
+
+- Fixed a bug in :meth:`tabmat.CategoricalMatrix.standardize` that sometimes returned ``nan`` values for the standard deviation due to numerical instability if using ``np.float32`` precision.
+
 4.0.1 - 2024-06-25
 ------------------
 

--- a/src/tabmat/categorical_matrix.py
+++ b/src/tabmat/categorical_matrix.py
@@ -672,7 +672,10 @@ class CategoricalMatrix(MatrixBase):
         # but because X_ij is either {0, 1}
         # we don't actually need to square.
         mean = self.transpose_matvec(weights)
-        return np.sqrt(mean - col_means**2)
+        vars = mean - col_means**2
+        # If using float32, we can get negative values due to precision errors
+        vars[vars < 0] = 0
+        return np.sqrt(vars)
 
     def __getitem__(self, item):
         row, col = _check_indexer(item)

--- a/src/tabmat/categorical_matrix.py
+++ b/src/tabmat/categorical_matrix.py
@@ -674,8 +674,7 @@ class CategoricalMatrix(MatrixBase):
         mean = self.transpose_matvec(weights)
         vars = mean - col_means**2
         # If using float32, we can get negative values due to precision errors
-        vars[vars < 0] = 0
-        return np.sqrt(vars)
+        return np.sqrt(np.maximum(vars, 0))
 
     def __getitem__(self, item):
         row, col = _check_indexer(item)


### PR DESCRIPTION
This fixes a bug in `CategoricalMatrix._get_col_stds`: We observed that if using `float32` precision, we'd sometimes get `nan`s as standard deviations for constant categorical columns. This would then lead to `nan` in `P1` and `P2` [here](https://github.com/Quantco/glum/blob/ef7ebe57313469461afa8c774d7e27543b0c284d/src/glum/_glm.py#L406).

To reproduce:
```python
import numpy as np
import tabmat
import pandas as pd
import glum

n = 1_234_456
rng = np.random.default_rng(0)
p = 0.00001

x = rng.choice([0, 1], p=[p, 1-p], size=n)
cat = pd.Categorical.from_codes(x, categories=np.array(range(3), dtype=np.int32))
mat = tabmat.CategoricalMatrix(cat, column_name="cat", dtype=np.float32)

y = np.random.choice([0, 1], size=n).astype(np.float32)

weights = np.ones(n, dtype=np.float32)
weights /= weights.sum()

X, means, col_stds = mat.standardize(weights, True, True)
print(f"means: {means}, col_stds: {col_stds}")

glm = glum.GeneralizedLinearRegressor(family="binomial", alpha=0.01, l1_ratio=0.5)
glm.fit(mat, y)
```

```
/Users/mlondschien/mambaforge/envs/icufm/lib/python3.10/site-packages/tabmat/categorical_matrix.py:607: RuntimeWarning: invalid value encountered in sqrt
  return np.sqrt(mean - col_means**2)
means: [9.7208804e-06 1.0003393e+00 0.0000000e+00], col_stds: [0.00311782        nan 0.        ]
/Users/mlondschien/mambaforge/envs/icufm/lib/python3.10/site-packages/tabmat/categorical_matrix.py:607: RuntimeWarning: invalid value encountered in sqrt
  return np.sqrt(mean - col_means**2)
Traceback (most recent call last):
  File "/Users/mlondschien/code/projects2024-icu-foundation/tmp_tabmat.py", line 22, in <module>
    glm.fit(mat, y)
  File "/Users/mlondschien/mambaforge/envs/icufm/lib/python3.10/site-packages/glum/_glm.py", line 3244, in fit
    coef = self._solve(
  File "/Users/mlondschien/mambaforge/envs/icufm/lib/python3.10/site-packages/glum/_glm.py", line 1113, in _solve
    coef, self.n_iter_, self._n_cycles, self.diagnostics_ = _irls_solver(
  File "/Users/mlondschien/mambaforge/envs/icufm/lib/python3.10/site-packages/glum/_solvers.py", line 288, in _irls_solver
    state.eta, state.mu, state.obj_val, coef_P2 = _update_predictions(
  File "/Users/mlondschien/mambaforge/envs/icufm/lib/python3.10/site-packages/glum/_solvers.py", line 638, in _update_predictions
    return eta_mu_objective(
  File "/Users/mlondschien/mambaforge/envs/icufm/lib/python3.10/site-packages/glum/_solvers.py", line 671, in eta_mu_objective
    obj_val += linalg.norm(P1 * coef[intercept_offset:], ord=1)
  File "/Users/mlondschien/mambaforge/envs/icufm/lib/python3.10/site-packages/scipy/linalg/_misc.py", line 146, in norm
    a = np.asarray_chkfinite(a)
  File "/Users/mlondschien/mambaforge/envs/icufm/lib/python3.10/site-packages/numpy/lib/function_base.py", line 628, in asarray_chkfinite
    raise ValueError(
ValueError: array must not contain infs or NaNs
```
Not sure where to test.