### PR TITLE
Check sandwich dimensions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Changelog
 
 - Added a new function, :func:`tabmat.from_polars`, to convert a :class:`polars.DataFrame` into a :class:`tabmat.SplitMatrix`.
 
+**Other changes:**
+
+- Added checks for dimension and ``dtype`` mismatch in :meth:`MatrixBasesandwich.sandwich`.
+
 **Bug fix:**
 
 - Fixed a bug in :meth:`tabmat.CategoricalMatrix.standardize` that sometimes returned ``nan`` values for the standard deviation due to numerical instability if using ``np.float32`` precision.

--- a/src/tabmat/categorical_matrix.py
+++ b/src/tabmat/categorical_matrix.py
@@ -186,7 +186,7 @@ from .matrix_base import MatrixBase
 from .sparse_matrix import SparseMatrix
 from .util import (
     _check_indexer,
-    check_matvec_compatible,
+    check_matvec_dimensions,
     check_matvec_out_shape,
     check_sandwich_compatible,
     check_transpose_matvec_out_shape,
@@ -421,7 +421,7 @@ class CategoricalMatrix(MatrixBase):
             raise NotImplementedError(
                 """CategoricalMatrix.matvec is only implemented for 1d arrays."""
             )
-        check_matvec_compatible(self, other, transpose=False)
+        check_matvec_dimensions(self, other, transpose=False)
 
         if cols is not None:
             if len(cols) == self.shape[1]:
@@ -521,7 +521,7 @@ class CategoricalMatrix(MatrixBase):
         # TODO: write a function that doesn't reference the data
         # TODO: this should look more like the cat_cat_sandwich
         vec = np.asarray(vec)
-        check_matvec_compatible(self, vec, transpose=True)
+        check_matvec_dimensions(self, vec, transpose=True)
         if vec.ndim > 1:
             raise NotImplementedError(
                 "CategoricalMatrix.transpose_matvec is only implemented for 1d arrays."

--- a/src/tabmat/categorical_matrix.py
+++ b/src/tabmat/categorical_matrix.py
@@ -186,8 +186,9 @@ from .matrix_base import MatrixBase
 from .sparse_matrix import SparseMatrix
 from .util import (
     _check_indexer,
-    check_matvec_dimensions,
+    check_matvec_compatible,
     check_matvec_out_shape,
+    check_sandwich_compatible,
     check_transpose_matvec_out_shape,
     set_up_rows_or_cols,
     setup_restrictions,
@@ -420,7 +421,7 @@ class CategoricalMatrix(MatrixBase):
             raise NotImplementedError(
                 """CategoricalMatrix.matvec is only implemented for 1d arrays."""
             )
-        check_matvec_dimensions(self, other, transpose=False)
+        check_matvec_compatible(self, other, transpose=False)
 
         if cols is not None:
             if len(cols) == self.shape[1]:
@@ -520,7 +521,7 @@ class CategoricalMatrix(MatrixBase):
         # TODO: write a function that doesn't reference the data
         # TODO: this should look more like the cat_cat_sandwich
         vec = np.asarray(vec)
-        check_matvec_dimensions(self, vec, transpose=True)
+        check_matvec_compatible(self, vec, transpose=True)
         if vec.ndim > 1:
             raise NotImplementedError(
                 "CategoricalMatrix.transpose_matvec is only implemented for 1d arrays."
@@ -578,6 +579,7 @@ class CategoricalMatrix(MatrixBase):
         matrix without making a copy.
         """
         d = np.asarray(d)
+        check_sandwich_compatible(self, d)
         rows = set_up_rows_or_cols(rows, self.shape[0])
         if self.drop_first or self._has_missings:
             res_diag = sandwich_categorical_complex(

--- a/src/tabmat/dense_matrix.py
+++ b/src/tabmat/dense_matrix.py
@@ -12,8 +12,9 @@ from .ext.dense import (
 from .matrix_base import MatrixBase
 from .util import (
     _check_indexer,
-    check_matvec_dimensions,
+    check_matvec_compatible,
     check_matvec_out_shape,
+    check_sandwich_compatible,
     check_transpose_matvec_out_shape,
     setup_restrictions,
 )
@@ -143,6 +144,7 @@ class DenseMatrix(MatrixBase):
     ) -> np.ndarray:
         """Perform a sandwich product: X.T @ diag(d) @ X."""
         d = np.asarray(d)
+        check_sandwich_compatible(self, d)
         rows, cols = setup_restrictions(self.shape, rows, cols)
         return dense_sandwich(self._array, d, rows, cols)
 
@@ -186,7 +188,7 @@ class DenseMatrix(MatrixBase):
         # filters rows and a version that only filters columns. How do we do
         # this without an explosion of code?
         vec = np.asarray(vec)
-        check_matvec_dimensions(self, vec, transpose=transpose)
+        check_matvec_compatible(self, vec, transpose=transpose)
         X = self._array.T if transpose else self._array
 
         # NOTE: We assume that rows and cols are unique

--- a/src/tabmat/dense_matrix.py
+++ b/src/tabmat/dense_matrix.py
@@ -12,7 +12,7 @@ from .ext.dense import (
 from .matrix_base import MatrixBase
 from .util import (
     _check_indexer,
-    check_matvec_compatible,
+    check_matvec_dimensions,
     check_matvec_out_shape,
     check_sandwich_compatible,
     check_transpose_matvec_out_shape,
@@ -188,7 +188,7 @@ class DenseMatrix(MatrixBase):
         # filters rows and a version that only filters columns. How do we do
         # this without an explosion of code?
         vec = np.asarray(vec)
-        check_matvec_compatible(self, vec, transpose=transpose)
+        check_matvec_dimensions(self, vec, transpose=transpose)
         X = self._array.T if transpose else self._array
 
         # NOTE: We assume that rows and cols are unique

--- a/src/tabmat/sparse_matrix.py
+++ b/src/tabmat/sparse_matrix.py
@@ -15,8 +15,9 @@ from .ext.sparse import (
 from .matrix_base import MatrixBase
 from .util import (
     _check_indexer,
-    check_matvec_dimensions,
+    check_matvec_compatible,
     check_matvec_out_shape,
+    check_sandwich_compatible,
     check_transpose_matvec_out_shape,
     set_up_rows_or_cols,
     setup_restrictions,
@@ -179,13 +180,7 @@ class SparseMatrix(MatrixBase):
     ) -> np.ndarray:
         """Perform a sandwich product: X.T @ diag(d) @ X."""
         d = np.asarray(d)
-        if not self.dtype == d.dtype:
-            raise TypeError(
-                f"""self and d need to be of same dtype, either np.float64
-                or np.float32. self is of type {self.dtype}, while d is of type
-                {d.dtype}."""
-            )
-
+        check_sandwich_compatible(self, d)
         rows, cols = setup_restrictions(self.shape, rows, cols, dtype=self.idx_dtype)
         return sparse_sandwich(self, self.array_csr, d, rows, cols)
 
@@ -242,7 +237,7 @@ class SparseMatrix(MatrixBase):
         transpose: bool,
     ):
         vec = np.asarray(vec)
-        check_matvec_dimensions(self, vec, transpose)
+        check_matvec_compatible(self, vec, transpose)
 
         unrestricted_rows = rows is None or len(rows) == self.shape[0]
         unrestricted_cols = cols is None or len(cols) == self.shape[1]

--- a/src/tabmat/sparse_matrix.py
+++ b/src/tabmat/sparse_matrix.py
@@ -15,7 +15,7 @@ from .ext.sparse import (
 from .matrix_base import MatrixBase
 from .util import (
     _check_indexer,
-    check_matvec_compatible,
+    check_matvec_dimensions,
     check_matvec_out_shape,
     check_sandwich_compatible,
     check_transpose_matvec_out_shape,
@@ -237,7 +237,7 @@ class SparseMatrix(MatrixBase):
         transpose: bool,
     ):
         vec = np.asarray(vec)
-        check_matvec_compatible(self, vec, transpose)
+        check_matvec_dimensions(self, vec, transpose)
 
         unrestricted_rows = rows is None or len(rows) == self.shape[0]
         unrestricted_cols = cols is None or len(cols) == self.shape[1]

--- a/src/tabmat/split_matrix.py
+++ b/src/tabmat/split_matrix.py
@@ -11,7 +11,7 @@ from .matrix_base import MatrixBase
 from .sparse_matrix import SparseMatrix
 from .standardized_mat import StandardizedMatrix
 from .util import (
-    check_matvec_compatible,
+    check_matvec_dimensions,
     check_matvec_out_shape,
     check_sandwich_compatible,
     check_transpose_matvec_out_shape,
@@ -378,10 +378,10 @@ class SplitMatrix(MatrixBase):
     ) -> np.ndarray:
         """Perform self[:, cols] @ other[cols]."""
         assert not isinstance(v, sps.spmatrix)
-        check_matvec_compatible(self, v, transpose=False)
+        v = np.asarray(v)
+        check_matvec_dimensions(self, v, transpose=False)
         check_matvec_out_shape(self, out)
 
-        v = np.asarray(v)
         if v.shape[0] != self.shape[1]:
             raise ValueError(f"shapes {self.shape} and {v.shape} not aligned")
 
@@ -437,10 +437,10 @@ class SplitMatrix(MatrixBase):
                 = sum_{j in rows} sum_{mat in self.matrices} 1(cols[i] in mat)
                                                             self[j, cols[i]] v[j]
         """
-        check_transpose_matvec_out_shape(self, out)
 
         v = np.asarray(v)
-        check_matvec_compatible(self, v, transpose=True)
+        check_matvec_dimensions(self, v, transpose=True)
+        check_transpose_matvec_out_shape(self, out)
 
         subset_cols_indices, subset_cols, n_cols = self._split_col_subsets(cols)
 

--- a/src/tabmat/split_matrix.py
+++ b/src/tabmat/split_matrix.py
@@ -11,7 +11,9 @@ from .matrix_base import MatrixBase
 from .sparse_matrix import SparseMatrix
 from .standardized_mat import StandardizedMatrix
 from .util import (
+    check_matvec_compatible,
     check_matvec_out_shape,
+    check_sandwich_compatible,
     check_transpose_matvec_out_shape,
     set_up_rows_or_cols,
 )
@@ -326,9 +328,8 @@ class SplitMatrix(MatrixBase):
         cols: Optional[np.ndarray] = None,
     ) -> np.ndarray:
         """Perform a sandwich product: X.T @ diag(d) @ X."""
-        if np.shape(d) != (self.shape[0],):
-            raise ValueError
         d = np.asarray(d)
+        check_sandwich_compatible(self, d)
 
         subset_cols_indices, subset_cols, n_cols = self._split_col_subsets(cols)
 
@@ -377,6 +378,7 @@ class SplitMatrix(MatrixBase):
     ) -> np.ndarray:
         """Perform self[:, cols] @ other[cols]."""
         assert not isinstance(v, sps.spmatrix)
+        check_matvec_compatible(self, v, transpose=False)
         check_matvec_out_shape(self, out)
 
         v = np.asarray(v)
@@ -438,6 +440,8 @@ class SplitMatrix(MatrixBase):
         check_transpose_matvec_out_shape(self, out)
 
         v = np.asarray(v)
+        check_matvec_compatible(self, v, transpose=True)
+
         subset_cols_indices, subset_cols, n_cols = self._split_col_subsets(cols)
 
         out_shape = [n_cols] + list(v.shape[1:])

--- a/src/tabmat/standardized_mat.py
+++ b/src/tabmat/standardized_mat.py
@@ -7,7 +7,7 @@ from .dense_matrix import DenseMatrix
 from .matrix_base import MatrixBase
 from .sparse_matrix import SparseMatrix
 from .util import (
-    check_matvec_compatible,
+    check_matvec_dimensions,
     check_sandwich_compatible,
     check_transpose_matvec_out_shape,
     set_up_rows_or_cols,
@@ -81,7 +81,7 @@ class StandardizedMatrix:
         cols = set_up_rows_or_cols(cols, self.shape[1])
 
         other_mat = np.asarray(other_mat)
-        check_matvec_compatible(self, other_mat, transpose=False)
+        check_matvec_dimensions(self, other_mat, transpose=False)
         mult_other = other_mat
         if self.mult is not None:
             mult = self.mult
@@ -196,7 +196,7 @@ class StandardizedMatrix:
         """
         check_transpose_matvec_out_shape(self, out)
         other = np.asarray(other)
-        check_matvec_compatible(self, other, transpose=True)
+        check_matvec_dimensions(self, other, transpose=True)
         res = self.mat.transpose_matvec(other, rows, cols)
 
         rows, cols = setup_restrictions(self.shape, rows, cols)

--- a/src/tabmat/standardized_mat.py
+++ b/src/tabmat/standardized_mat.py
@@ -7,7 +7,8 @@ from .dense_matrix import DenseMatrix
 from .matrix_base import MatrixBase
 from .sparse_matrix import SparseMatrix
 from .util import (
-    check_matvec_dimensions,
+    check_matvec_compatible,
+    check_sandwich_compatible,
     check_transpose_matvec_out_shape,
     set_up_rows_or_cols,
     setup_restrictions,
@@ -80,7 +81,7 @@ class StandardizedMatrix:
         cols = set_up_rows_or_cols(cols, self.shape[1])
 
         other_mat = np.asarray(other_mat)
-        check_matvec_dimensions(self, other_mat, transpose=False)
+        check_matvec_compatible(self, other_mat, transpose=False)
         mult_other = other_mat
         if self.mult is not None:
             mult = self.mult
@@ -128,12 +129,7 @@ class StandardizedMatrix:
         """Perform a sandwich product: X.T @ diag(d) @ X."""
         if not hasattr(d, "dtype"):
             d = np.asarray(d)
-        if not self.mat.dtype == d.dtype:
-            raise TypeError(
-                f"""self.mat and d need to be of same dtype, either
-                np.float64 or np.float32. This matrix is of type {self.mat.dtype},
-                while d is of type {d.dtype}."""
-            )
+        check_sandwich_compatible(self, d)
 
         if rows is not None or cols is not None:
             setup_rows, setup_cols = setup_restrictions(self.shape, rows, cols)
@@ -200,7 +196,7 @@ class StandardizedMatrix:
         """
         check_transpose_matvec_out_shape(self, out)
         other = np.asarray(other)
-        check_matvec_dimensions(self, other, transpose=True)
+        check_matvec_compatible(self, other, transpose=True)
         res = self.mat.transpose_matvec(other, rows, cols)
 
         rows, cols = setup_restrictions(self.shape, rows, cols)

--- a/src/tabmat/util.py
+++ b/src/tabmat/util.py
@@ -42,13 +42,34 @@ def check_matvec_out_shape(mat, out: Optional[np.ndarray]) -> None:
     _check_out_shape(out, mat.shape[0])
 
 
-def check_matvec_dimensions(mat, vec: np.ndarray, transpose: bool) -> None:
+def check_matvec_compatible(mat, vec: np.ndarray, transpose: bool) -> None:
     """Assert that the dimensions for the matvec operation are compatible."""
     match_dim = 0 if transpose else 1
     if mat.shape[match_dim] != vec.shape[0]:
         raise ValueError(
             f"shapes {mat.shape} and {vec.shape} not aligned: "
             f"{mat.shape[match_dim]} (dim {match_dim}) != {vec.shape[0]} (dim 0)"
+        )
+    if not mat.dtype == vec.dtype:
+        raise TypeError(
+            f"""mat and vec need to be of same dtype, either np.float64
+            or np.float32. mat is of type {mat.dtype}, while vec is of type
+            {vec.dtype}."""
+        )
+
+
+def check_sandwich_compatible(mat, d: np.ndarray):
+    """Assert that the dimensions and dtypes for the sandwich product are compatible."""
+    if mat.shape[0] != d.shape[0]:
+        raise ValueError(
+            f"shapes {mat.shape} and {d.shape} not aligned: "
+            f"{mat.shape[0]} (dim 0) != {d.shape[0]} (dim 0)"
+        )
+    if not mat.dtype == d.dtype:
+        raise TypeError(
+            f"""self and d need to be of same dtype, either np.float64
+            or np.float32. self is of type {mat.dtype}, while d is of type
+            {d.dtype}."""
         )
 
 

--- a/src/tabmat/util.py
+++ b/src/tabmat/util.py
@@ -42,19 +42,13 @@ def check_matvec_out_shape(mat, out: Optional[np.ndarray]) -> None:
     _check_out_shape(out, mat.shape[0])
 
 
-def check_matvec_compatible(mat, vec: np.ndarray, transpose: bool) -> None:
+def check_matvec_dimensions(mat, vec: np.ndarray, transpose: bool) -> None:
     """Assert that the dimensions for the matvec operation are compatible."""
     match_dim = 0 if transpose else 1
     if mat.shape[match_dim] != vec.shape[0]:
         raise ValueError(
             f"shapes {mat.shape} and {vec.shape} not aligned: "
             f"{mat.shape[match_dim]} (dim {match_dim}) != {vec.shape[0]} (dim 0)"
-        )
-    if not mat.dtype == vec.dtype:
-        raise TypeError(
-            f"""mat and vec need to be of same dtype, either np.float64
-            or np.float32. mat is of type {mat.dtype}, while vec is of type
-            {vec.dtype}."""
         )
 
 

--- a/tests/test_matrices.py
+++ b/tests/test_matrices.py
@@ -195,14 +195,6 @@ def test_matvec_dimension_mismatch_raises(mat, rows, cols):
 
 
 @pytest.mark.parametrize("mat", get_matrices())
-def test_matvec_dtype_mismatch_raises(mat):
-    with pytest.raises(TypeError, match="same dtype"):
-        mat.astype(np.float64).matvec(np.ones(mat.shape[1], dtype=np.float32))
-    with pytest.raises(TypeError, match="same dtype"):
-        mat.astype(np.float32).matvec(np.ones(mat.shape[1], dtype=np.float64))
-
-
-@pytest.mark.parametrize("mat", get_matrices())
 @pytest.mark.parametrize("cols", [None, [], [1], np.array([0, 1])])
 @pytest.mark.parametrize("rows", [None, [], [1], np.array([0, 2])])
 def test_sandwich_dimension_mismatch_raises(mat, rows, cols):

--- a/tests/test_matrices.py
+++ b/tests/test_matrices.py
@@ -195,6 +195,36 @@ def test_matvec_dimension_mismatch_raises(mat, rows, cols):
 
 
 @pytest.mark.parametrize("mat", get_matrices())
+def test_matvec_dtype_mismatch_raises(mat):
+    with pytest.raises(TypeError, match="same dtype"):
+        mat.astype(np.float64).matvec(np.ones(mat.shape[1], dtype=np.float32))
+    with pytest.raises(TypeError, match="same dtype"):
+        mat.astype(np.float32).matvec(np.ones(mat.shape[1], dtype=np.float64))
+
+
+@pytest.mark.parametrize("mat", get_matrices())
+@pytest.mark.parametrize("cols", [None, [], [1], np.array([0, 1])])
+@pytest.mark.parametrize("rows", [None, [], [1], np.array([0, 2])])
+def test_sandwich_dimension_mismatch_raises(mat, rows, cols):
+    too_short = np.ones(mat.shape[0] - 1, dtype=mat.dtype)
+    just_right = np.ones(mat.shape[0], dtype=mat.dtype)
+    too_long = np.ones(mat.shape[0] + 1, dtype=mat.dtype)
+    mat.sandwich(just_right, cols=cols)
+    with pytest.raises(ValueError, match="not aligned"):
+        mat.sandwich(too_short, cols=cols)
+    with pytest.raises(ValueError, match="not aligned"):
+        mat.sandwich(too_long, cols=cols)
+
+
+@pytest.mark.parametrize("mat", get_matrices())
+def test_sandwich_dtype_mismatch_raises(mat):
+    with pytest.raises(TypeError, match="same dtype"):
+        mat.astype(np.float64).sandwich(np.ones(mat.shape[0], dtype=np.float32))
+    with pytest.raises(TypeError, match="same dtype"):
+        mat.astype(np.float32).sandwich(np.ones(mat.shape[0], dtype=np.float64))
+
+
+@pytest.mark.parametrize("mat", get_matrices())
 @pytest.mark.parametrize("i", [1, -2])
 def test_getcol(mat: Union[tm.MatrixBase, tm.StandardizedMatrix], i):
     col = mat.getcol(i)

--- a/tests/test_split_matrix.py
+++ b/tests/test_split_matrix.py
@@ -305,4 +305,4 @@ def test_matvec(n_rows):
         "category"
     )
     mat = from_pandas(X, cat_threshold=0)
-    np.testing.assert_allclose(mat.matvec(np.array(mat.shape[1] * [1])), n_cols)
+    np.testing.assert_allclose(mat.matvec(np.ones(mat.shape[1])), n_cols)

--- a/tests/test_split_matrix.py
+++ b/tests/test_split_matrix.py
@@ -305,4 +305,4 @@ def test_matvec(n_rows):
         "category"
     )
     mat = from_pandas(X, cat_threshold=0)
-    np.testing.assert_allclose(mat.matvec(np.ones(mat.shape[1])), n_cols)
+    np.testing.assert_allclose(mat.matvec(np.array(mat.shape[1] * [1])), n_cols)


### PR DESCRIPTION
<!-- ⚠️ This is an open-source repository. Do not share sensitive information. -->

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a `CHANGELOG.rst` entry

Add checks to raise an informative error on dimension or dtype mismatch in `MatrixBase.sandwich`. Before this, a dimension mismatch led to either `np.nan`s or simpoly wrong output depending on the platform.
