### PR TITLE
Drop SciPy from nightly CI

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -11,7 +11,6 @@ cmd = """
     PRE_WHEELS="https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/"
     && pip install --pre --no-deps --only-binary :all: --upgrade --timeout=60 -i $PRE_WHEELS numpy
     && pip install --pre --no-deps --only-binary :all: --upgrade --timeout=60 -i $PRE_WHEELS pandas
-    && pip install --pre --no-deps --only-binary :all: --upgrade --timeout=60 -i $PRE_WHEELS scipy
     && pip install --pre --no-deps --only-binary :all: --upgrade --timeout=60 -i https://pypi.fury.io/arrow-nightlies/ pyarrow
     && pip install --no-deps git+https://github.com/matthewwardrop/formulaic
 """


### PR DESCRIPTION
Missing wheels are the only grief SciPy has ever given us.

Closes #401.