### PR TITLE
Fix glum issue-872

### DIFF
--- a/src/tabmat/standardized_mat.py
+++ b/src/tabmat/standardized_mat.py
@@ -147,8 +147,9 @@ class StandardizedMatrix:
 
         limited_shift = self.shift[cols] if cols is not None else self.shift
         limited_d = d[rows] if rows is not None else d
-        term3_and_4 = np.outer(limited_shift, d_mat + limited_shift * np.sum(limited_d))
-        res = term2 + term3_and_4
+        term3 = np.outer(limited_shift, d_mat)
+        term4 = np.outer(limited_shift, limited_shift) * np.sum(limited_d)
+        res = term2 + term3 + term4
         if isinstance(term1, sps.dia_matrix):
             idx = np.arange(res.shape[0])
             to_add = term1.data[0, :]


### PR DESCRIPTION
![](https://images.squarespace-cdn.com/content/v1/5a05ececd55b4165f250f032/1542045347481-ET7TCLLBH4WGSY2J7QK6/fa5.jpg)
but this fixes https://github.com/Quantco/glum/issues/872 for me. I still get a warning
```
Iteration 99:   8%|████████████▎                                                                                                                                     | 0.42/5.0 [0.07s/it, gradient norm=3.834443702192064]
/Users/mlondschien/mambaforge/envs/icu-experiments/lib/python3.10/site-packages/glum/_solvers.py:336: ConvergenceWarning: IRLS failed to converge. Increase the maximum number of iterations max_iter (currently 100)
  warnings.warn(
```