### PR TITLE
Adjust tests to new formulaic behavior

### DIFF
--- a/tests/test_formula.py
+++ b/tests/test_formula.py
@@ -480,19 +480,29 @@ def test_all_names_against_from_pandas(df, categorical_format):
         pytest.param(
             "1 + C(cat_1, spans_intercept=False) * cat_2 * cat_3",
             id="custom_contrasts",
+            marks=pytest.mark.xfail(
+                reason="Non-uniform categorical formats are not yet supported"
+            ),
         ),
     ],
 )
 def test_names_against_pandas(df, formula, ensure_full_rank):
+    if ensure_full_rank:
+        categorical_format = "{name}[T.{category}]"
+    else:
+        categorical_format = "{name}[{category}]"
+
     num_in_scope = 2  # noqa
+
     model_df = formulaic.model_matrix(formula, df, ensure_full_rank=ensure_full_rank)
     model_tabmat = tm.from_formula(
         formula,
         df,
         ensure_full_rank=ensure_full_rank,
-        categorical_format="{name}[T.{category}]",
+        categorical_format=categorical_format,
         context=0,
     )
+
     assert model_tabmat.model_spec.column_names == model_df.model_spec.column_names
     assert model_tabmat.model_spec.column_names == tuple(model_df.columns)
     assert model_tabmat.column_names == list(model_df.columns)

--- a/tests/test_formula.py
+++ b/tests/test_formula.py
@@ -457,6 +457,7 @@ def test_all_names_against_from_pandas(df, categorical_format):
     assert mat_from_formula.term_names == mat_from_pandas.term_names
 
 
+@pytest.mark.skip(reason="We handle categorical names differently from formulaic")
 @pytest.mark.parametrize(
     "ensure_full_rank", [True, False], ids=["full_rank", "all_levels"]
 )


### PR DESCRIPTION
Fixes #418.

Formulaic [#220](https://github.com/matthewwardrop/formulaic/pull/220) introduced a change in the names for categorical columns: instead of a common `{column}[T.{category}]` format, formulaic now only uses the latter for treatment-encoded variables (i.e., `ensure_full_rank=True`), and uses our default (`{column}[{category}]`) for the rest.

As we have a different default behavior anyways, I don't think we want to follow this change, so I just removed the test (otherwise either the nightlies or the non-nightlies will fail). Furthermore, our implementation does not currently allow for different categorical variables having different formats, so there is one test case which would be impossible to satisfy anyways. We already have a number of other test to make sure that the categorical names we create match _our_ expectations, IMO those should suffice.

<!-- ⚠️ This is an open-source repository. Do not share sensitive information. -->

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a `CHANGELOG.rst` entry
