### PR TITLE
Fix breakage caused by changes in formulaic

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-14]
+        os: [ubuntu-20.04, windows-2019, macos-12]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-12]
+        os: [ubuntu-20.04, windows-2019, macos-14]
 
     steps:
       - uses: actions/checkout@v4

--- a/src/tabmat/formula.py
+++ b/src/tabmat/formula.py
@@ -10,7 +10,6 @@ import pandas
 from formulaic import ModelMatrix, ModelSpec
 from formulaic.errors import FactorEncodingError
 from formulaic.materializers import FormulaMaterializer
-from formulaic.materializers.base import EncodedTermStructure
 from formulaic.materializers.types import FactorValues, NAAction, ScopedTerm
 from formulaic.parser.types import Term
 from formulaic.transforms import stateful_transform
@@ -23,6 +22,11 @@ from .dense_matrix import DenseMatrix
 from .matrix_base import MatrixBase
 from .sparse_matrix import SparseMatrix
 from .split_matrix import SplitMatrix
+
+try:
+    from formulaic.materializers.base import EncodedTermStructure
+except ImportError:
+    from formulaic.materializers.types.formula_materializer import EncodedTermStructure
 
 
 class TabmatMaterializer(FormulaMaterializer):


### PR DESCRIPTION
It seems like formulaic might be considering the `EncodedTermStructure` a private class based on the fact that it is being moved in a non-major release. A bigger refactor of the `formula` module might be worth considering at some point now that formulaic reached 1.0 and is more stable. Until then, this PR provides a quick fix for #422.

<!-- ⚠️ This is an open-source repository. Do not share sensitive information. -->

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a `CHANGELOG.rst` entry
