### PR TITLE
Update macOS runner

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-12]
+        os: [ubuntu-20.04, windows-2019, macos-13]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-13]
+        os: [ubuntu-20.04, windows-2019, macos-13, macos-14]
 
     steps:
       - uses: actions/checkout@v4
@@ -28,15 +28,11 @@ jobs:
         uses: pypa/cibuildwheel@v2.22.0
         env:
           CIBW_ARCHS_LINUX: auto
-          CIBW_ARCHS_MACOS: x86_64 arm64
-          CIBW_TEST_SKIP: '*-macosx_arm64'
       - name: Build wheels (release)
         if: github.event_name == 'release' && github.event.action == 'published'
         uses: pypa/cibuildwheel@v2.22.0
         env:
           CIBW_ARCHS_LINUX: x86_64 aarch64
-          CIBW_ARCHS_MACOS: x86_64 arm64
-          CIBW_TEST_SKIP: '*-macosx_arm64'
       - uses: actions/upload-artifact@v4
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}

--- a/build_tools/prepare_macos_wheel.sh
+++ b/build_tools/prepare_macos_wheel.sh
@@ -2,10 +2,4 @@
 
 set -exuo pipefail
 
-if [[ "${ARCHFLAGS:-}" == *arm64 ]]; then
-    export CONDA_SUBDIR="osx-arm64"
-else
-    export CONDA_SUBDIR="osx-64"
-fi
-
 /Users/runner/micromamba-bin/micromamba create -y -p $MAMBA_ROOT_PREFIX/envs/build -c conda-forge jemalloc-local "xsimd<11|>12.1" llvm-openmp

--- a/build_tools/prepare_macos_wheel.sh
+++ b/build_tools/prepare_macos_wheel.sh
@@ -8,4 +8,4 @@ else
     export CONDA_SUBDIR="osx-64"
 fi
 
-/Users/runner/micromamba-bin/micromamba create -y -p $CONDA/envs/build -c conda-forge jemalloc-local "xsimd<11|>12.1" llvm-openmp
+/Users/runner/micromamba-bin/micromamba create -y -p $MAMBA_ROOT_PREFIX/envs/build -c conda-forge jemalloc-local "xsimd<11|>12.1" llvm-openmp

--- a/build_tools/prepare_macos_wheel.sh
+++ b/build_tools/prepare_macos_wheel.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-set -exuo pipefail
-
-/Users/runner/micromamba-bin/micromamba create -y -p $MAMBA_ROOT_PREFIX/envs/build -c conda-forge jemalloc-local "xsimd<11|>12.1" llvm-openmp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,9 +61,9 @@ before-build = [
 ]
 
 [tool.cibuildwheel.macos.environment]
-LDFLAGS="-Wl,-rpath,$CONDA/envs/build/lib -L$CONDA/envs/build/lib -headerpad_max_install_names"
-CFLAGS="-I$CONDA/envs/build/include"
-CXXFLAGS="-I$CONDA/envs/build/include"
+LDFLAGS="-Wl,-rpath,$MAMBA_ROOT_PREFIX/envs/build/lib -L$MAMBA_ROOT_PREFIX/envs/build/lib -headerpad_max_install_names"
+CFLAGS="-I$MAMBA_ROOT_PREFIX/envs/build/include"
+CXXFLAGS="-I$MAMBA_ROOT_PREFIX/envs/build/include"
 CXX="/usr/bin/clang++"
 CC="/usr/bin/clang"
 JE_INSTALL_SUFFIX="local"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ test-command = "pytest {package}/tests/test_matrices.py"
 
 [tool.cibuildwheel.macos]
 before-build = [
-  "bash build_tools/prepare_macos_wheel.sh",
+  "/Users/runner/micromamba-bin/micromamba create -y -p $MAMBA_ROOT_PREFIX/envs/build -c conda-forge jemalloc-local \"xsimd<11|>12.1\" llvm-openmp",
 ]
 
 [tool.cibuildwheel.macos.environment]


### PR DESCRIPTION
macos-12 is now deprecated, so moving to macos-13. This is the last runner using Intel chips. With the new apple silicon runners, we can build the arm version natively, which makes it much simpler.


<!-- ⚠️ This is an open-source repository. Do not share sensitive information. -->



<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a `CHANGELOG.rst` entry
