### PR TITLE
Fix formulaic reference

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @MarcAntoineSchmidtQC @xhochy @jtilly @lbittarello
+* @MarcAntoineSchmidtQC @jtilly @lbittarello @stanmart

--- a/tests/test_formula.py
+++ b/tests/test_formula.py
@@ -11,6 +11,11 @@ from formulaic.materializers.types import EvaluatedFactor, FactorValues
 from formulaic.parser.types import Factor
 from scipy import sparse as sps
 
+try:
+    from formulaic.utils.structured import Structured
+except ImportError:
+    from formulaic.parser.types import Structured
+
 import tabmat as tm
 from tabmat.formula import (
     TabmatMaterializer,
@@ -1145,5 +1150,5 @@ class TestFormulaicTests:
         pickle.dump(ms.model_spec, o)
         o.seek(0)
         ms2 = pickle.load(o)
-        assert isinstance(ms, formulaic.parser.types.Structured)
+        assert isinstance(ms, Structured)
         assert ms2.lhs.formula.root == ["a"]


### PR DESCRIPTION
<!-- ⚠️ This is an open-source repository. Do not share sensitive information. -->

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a `CHANGELOG.rst` entry

We forgot one reference in #423. I've manually run the nightly here: https://github.com/Quantco/tabmat/actions/runs/12187514125

I also changed the codeowner file: removed @xhochy and added @stanmart. I believe Uwe was already removed of glum, so him being left in tabmat was probably an oversight.

