### PR TITLE
Build linux-aarch64 wheels on native arm runners

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -12,28 +12,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-13, macos-14]
+        os: [ubuntu-22.04, ubuntu-22.04, windows-2019, macos-13, macos-14]
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up QEMU
-        if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v8.1.5
       - name: Set up micromamba
         uses: mamba-org/setup-micromamba@0dea6379afdaffa5d528b3d1dabc45da37f443fc
       - name: Build wheels
-        if: github.event_name != 'release'
         uses: pypa/cibuildwheel@v2.22.0
-        env:
-          CIBW_ARCHS_LINUX: auto
-      - name: Build wheels (release)
-        if: github.event_name == 'release' && github.event.action == 'published'
-        uses: pypa/cibuildwheel@v2.22.0
-        env:
-          CIBW_ARCHS_LINUX: x86_64 aarch64
       - uses: actions/upload-artifact@v4
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -2,6 +2,11 @@ name: Build and upload to PyPI
 
 on:
   pull_request:
+  push:
+    branches:
+      - "main"
+    tags:
+      - "*"
   release:
     types:
       - published

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-22.04, windows-2019, macos-13, macos-14]
+        os: [ubuntu-22.04, ubuntu-22.04-arm, windows-2019, macos-13, macos-14]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -1,11 +1,15 @@
 name: conda-build
 on:
+  # We would like to trigger for CI for any pull request action -
+  # both from QuantCo's branches as well as forks.
   pull_request:
-    branches:
-      - main
+  # In addition to pull requests, we want to run CI for pushes
+  # to the main branch and tags.
   push:
     branches:
-      - main
+      - "main"
+    tags:
+      - "*"
 
 jobs:
   conda-build:


### PR DESCRIPTION
<!-- ⚠️ This is an open-source repository. Do not share sensitive information. -->

Should be much faster and we can hopefully avoid issues like #439. I also enabled building linux-aarch64 wheels for PRs, just like for the other platforms.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a `CHANGELOG.rst` entry
