### PR TITLE
Fix column validation when all levels of a categorical are dropped while ensuring full rank

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,8 @@ Changelog
 
 **Bug fix:**
 
-- Fixed a bug which incorrectly raised an error when constructing tabmat matrices from existing ``ModelSpec``s when they contained a categorical column without any levels.
+- Fixed a bug which caused issues when constructing tabmat matrices from existing ``ModelSpec``\s when they contained categorical columns with all levels dropped.
+
 
 4.1.1 - 2025-01-30
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,13 @@
 Changelog
 =========
 
+4.1.2 - UNRELEASED
+------------------
+
+**Bug fix:**
+
+- Fixed a bug which incorrectly raised an error when constructing tabmat matrices from existing ``ModelSpec``s when they contained a categorical column without any levels.
+
 4.1.1 - 2025-01-30
 ------------------
 

--- a/src/tabmat/formula.py
+++ b/src/tabmat/formula.py
@@ -777,8 +777,9 @@ def _replace_sequence(lst: list[str], sequence: list[str], replacement: "str") -
     """
     try:
         start = lst.index(sequence[0])
-    except ValueError:
-        start = 0  # Will handle this below
+    except (ValueError, KeyError):
+        # If the subsequence does not match, we'll still catch it below
+        start = 0
 
     for elem in sequence:
         if lst[start] != elem:

--- a/src/tabmat/formula.py
+++ b/src/tabmat/formula.py
@@ -475,10 +475,21 @@ class _InteractableCategoricalVector(_InteractableVector):
         dtype: numpy.typing.DTypeLike = np.float64,
         sparse_threshold: float = 0.1,
         cat_threshold: int = 4,
-    ) -> Union[DenseMatrix, CategoricalMatrix, SplitMatrix]:
+    ) -> Union[CategoricalMatrix, SparseMatrix, SplitMatrix]:
         codes = self.codes.copy()
         categories = self.categories.copy()
         if -2 in self.codes:
+            if (self.codes == -2).all():
+                # All values are dropped
+                return SparseMatrix(
+                    sps.csc_matrix(
+                        ([], ([], [])),
+                        shape=(len(codes), len(categories)),
+                        dtype=dtype,
+                    ),
+                    dtype=dtype,
+                )
+
             codes[codes >= 0] += 1
             codes[codes == -2] = 0
             categories.insert(0, "__drop__")
@@ -501,10 +512,7 @@ class _InteractableCategoricalVector(_InteractableVector):
             cat_missing_method="zero",  # missing values are already handled
         )
 
-        if (self.codes == -2).all():
-            # All values are dropped
-            return DenseMatrix(np.empty((len(codes), 0), dtype=dtype))
-        elif (self.multipliers == 1).all() and len(categories) >= cat_threshold:
+        if (self.multipliers == 1).all() and len(categories) >= cat_threshold:
             return categorical_part
         else:
             sparse_matrix = sps.csc_matrix(
@@ -777,7 +785,7 @@ def _replace_sequence(lst: list[str], sequence: list[str], replacement: "str") -
     """
     try:
         start = lst.index(sequence[0])
-    except (ValueError, KeyError):
+    except (ValueError, IndexError):
         # If the subsequence does not match, we'll still catch it below
         start = 0
 

--- a/tests/test_formula.py
+++ b/tests/test_formula.py
@@ -832,6 +832,17 @@ def test_unseen_missing(cat_missing_method):
         assert result_unseen.column_names == ["cat_1[a]", "cat_1[b]"]
 
 
+def test_drop_all_levels():
+    df = pd.DataFrame(
+        {
+            "cat_1": ["A", "A", "A"],
+        }
+    )
+    X = tm.from_formula("C(cat_1) + 1", df, ensure_full_rank=True)
+    X_repl = X.model_spec.get_model_matrix(df)
+    np.testing.assert_array_equal(X.toarray(), X_repl.toarray())
+
+
 # Tests from formulaic's test suite
 # ---------------------------------
 

--- a/tests/test_formula.py
+++ b/tests/test_formula.py
@@ -835,7 +835,7 @@ def test_unseen_missing(cat_missing_method):
 def test_drop_all_levels():
     df = pd.DataFrame(
         {
-            "cat_1": ["A", "A", "A"],
+            "cat_1": pd.Categorical(["A", "A", "A"], categories=["A", "B"]),
         }
     )
     X = tm.from_formula("C(cat_1) + 1", df, ensure_full_rank=True)


### PR DESCRIPTION
This PR fixes [glum #918](https://github.com/Quantco/glum/issues/918). The cause of the issue was that we have to do a bit of work for `formulaic` to be able to validate the generated columns when generating the model matrix from an already existing `ModelSpec`, and we missed the case where a categorical variable would have zero categories.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Added a `CHANGELOG.rst` entry
