### PR TITLE
Fix CI buildwheel on Windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ before-all = [
 ]
 
 [tool.cibuildwheel.windows.environment]
-INCLUDE="D:\\\\a\\\\tabmat\\\\tabmat\\\\envs\\\\build\\\\Library\\\\include"
+INCLUDE="C:\\\\a\\\\tabmat\\\\tabmat\\\\envs\\\\build\\\\Library\\\\include"
 
 [tool.cibuildwheel.linux]
 before-all = [


### PR DESCRIPTION
Somehow the default working directory got moved to `C:\`.

Successful CI run: https://github.com/Quantco/tabmat/actions/runs/15211468031