### PR TITLE
Use `tolist` method to obtain native types

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
-  'setuptools', 
-  'setuptools-scm', 
+  'setuptools',
+  'setuptools-scm',
   'wheel',
   'mako',
   'numpy>=1.25',
@@ -44,7 +44,7 @@ ignore_missing_imports = true
 skip = [
   "*-win32",
   "*-manylinux_i686",
-  "pp*", 
+  "pp*",
   "*-musllinux_*",
   "cp36*",
   "cp37*",

--- a/src/tabmat/dense_matrix.py
+++ b/src/tabmat/dense_matrix.py
@@ -64,8 +64,8 @@ class DenseMatrix(MatrixBase):
 
     def __getitem__(self, key):
         row, col = _check_indexer(key)
-        colnames = list(np.array(self.column_names)[col].ravel())
-        terms = list(np.array(self.term_names)[col].ravel())
+        colnames = np.array(self.column_names)[col].ravel().tolist()
+        terms = np.array(self.term_names)[col].ravel().tolist()
 
         return type(self)(
             self._array.__getitem__((row, col)), column_names=colnames, term_names=terms
@@ -304,7 +304,7 @@ class DenseMatrix(MatrixBase):
             default_names = np.array([f"{missing_prefix}{i}" for i in indices])
             names[names == None] = default_names[names == None]  # noqa: E711
 
-        return list(names)
+        return names.tolist()
 
     def set_names(self, names: Union[str, list[Optional[str]]], type: str = "column"):
         """Set column names.

--- a/src/tabmat/formula.py
+++ b/src/tabmat/formula.py
@@ -437,7 +437,7 @@ class _InteractableCategoricalVector(_InteractableVector):
         add_missing_category: bool = False,
     ) -> "_InteractableCategoricalVector":
         """Create an interactable categorical vector from a pandas categorical."""
-        categories = list(cat.categories)
+        categories = cat.categories.tolist()
         codes = cat.codes.copy().astype(np.int64)
 
         if reduced_rank:

--- a/src/tabmat/sparse_matrix.py
+++ b/src/tabmat/sparse_matrix.py
@@ -80,8 +80,8 @@ class SparseMatrix(MatrixBase):
 
     def __getitem__(self, key):
         row, col = _check_indexer(key)
-        colnames = list(np.array(self.column_names)[col].ravel())
-        terms = list(np.array(self.term_names)[col].ravel())
+        colnames = np.array(self.column_names)[col].ravel().tolist()
+        terms = np.array(self.term_names)[col].ravel().tolist()
 
         return type(self)(
             self._array.__getitem__((row, col)), column_names=colnames, term_names=terms
@@ -378,7 +378,7 @@ class SparseMatrix(MatrixBase):
             default_names = np.array([f"{missing_prefix}{i}" for i in indices])
             names[names == None] = default_names[names == None]  # noqa: E711
 
-        return list(names)
+        return names.tolist()
 
     def set_names(self, names: Union[str, list[Optional[str]]], type: str = "column"):
         """Set column names.

--- a/src/tabmat/split_matrix.py
+++ b/src/tabmat/split_matrix.py
@@ -125,8 +125,8 @@ def _combine_matrices(matrices, indices):
             )
             sorter = np.argsort(new_indices)
             sorted_matrix = new_matrix[:, sorter]
-            sorted_matrix._colnames = list(new_colnames[sorter])
-            sorted_matrix._terms = list(new_terms[sorter])
+            sorted_matrix._colnames = new_colnames[sorter].tolist()
+            sorted_matrix._terms = new_terms[sorter].tolist()
             sorted_indices = new_indices[sorter]
 
             assert sorted_matrix.shape[0] == n_row
@@ -530,7 +530,7 @@ class SplitMatrix(MatrixBase):
         names = np.empty(self.shape[1], dtype=object)
         for idx, mat in zip(self.indices, self.matrices):
             names[idx] = mat.get_names(type, missing_prefix, idx)
-        return list(names)
+        return names.tolist()
 
     def set_names(self, names: Union[str, list[Optional[str]]], type: str = "column"):
         """Set column names.
@@ -551,4 +551,4 @@ class SplitMatrix(MatrixBase):
             raise ValueError(f"Length of names must be {self.shape[1]}")
 
         for idx, mat in zip(self.indices, self.matrices):
-            mat.set_names(list(names_array[idx]), type)
+            mat.set_names(names_array[idx].tolist(), type)

--- a/tests/test_constructor.py
+++ b/tests/test_constructor.py
@@ -192,4 +192,4 @@ def test_names_polars(prefix_sep, drop_first):
     )
 
     unique_terms = list(dict.fromkeys(mat_expand.term_names))
-    assert unique_terms == list(df.columns)
+    assert unique_terms == df.columns

--- a/tests/test_formula.py
+++ b/tests/test_formula.py
@@ -517,7 +517,7 @@ def test_names_against_pandas(df, formula, ensure_full_rank):
 
     assert model_tabmat.model_spec.column_names == model_df.model_spec.column_names
     assert model_tabmat.model_spec.column_names == tuple(model_df.columns)
-    assert model_tabmat.column_names == list(model_df.columns)
+    assert model_tabmat.column_names == model_df.columns.tolist()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_matrices.py
+++ b/tests/test_matrices.py
@@ -796,8 +796,8 @@ def test_names_indexing(indexer_1, indexer_2, sparse):
     X_indexed = X[indexer_1, indexer_2]
     if not isinstance(X_indexed, tm.MatrixBase):
         pytest.skip("Does not return MatrixBase")
-    assert X_indexed.column_names == list(colnames_array[indexer_2])
-    assert X_indexed.term_names == list(termnames_array[indexer_2])
+    assert X_indexed.column_names == colnames_array[indexer_2].tolist()
+    assert X_indexed.term_names == termnames_array[indexer_2].tolist()
 
 
 @pytest.mark.parametrize("mat_1", get_all_matrix_base_subclass_mats())


### PR DESCRIPTION
Calling `list` on a NumPy array produces a list of NumPy scalars, which is a bit odd. `tolist` produces a list of native scalars.