### PR TITLE
stay on windows 2022 runners for now.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           - { os: ubuntu-latest, environment: 'py312' }
           - { os: ubuntu-latest, environment: 'py313' }
           - { os: ubuntu-latest, environment: 'py314' }
-          - { os: windows-latest, environment: 'py314' }
+          - { os: windows-2022, environment: 'py314' }
           - { os: macos-latest, environment: 'py314' }
           - { os: ubuntu-latest, environment: 'oldies' }
           - { os: ubuntu-latest, environment: 'nightly' }

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -25,8 +25,8 @@ jobs:
           - { conda_build_yml: osx_64_python3.11.____cpython,           os: macos-latest,   conda-build-args: ' --no-test' }
           - { conda_build_yml: osx_arm64_python3.10.____cpython,        os: macos-latest,   conda-build-args: '' }
           - { conda_build_yml: osx_arm64_python3.13.____cp313,          os: macos-latest,   conda-build-args: '' }
-          - { conda_build_yml: win_64_python3.10.____cpython,           os: windows-latest, conda-build-args: '' }
-          - { conda_build_yml: win_64_python3.13.____cp313,             os: windows-latest, conda-build-args: '' }
+          - { conda_build_yml: win_64_python3.10.____cpython,           os: windows-2022, conda-build-args: '' }
+          - { conda_build_yml: win_64_python3.13.____cp313,             os: windows-2022, conda-build-args: '' }
 
     steps:
       - name: Checkout branch
@@ -35,7 +35,7 @@ jobs:
         run: git fetch --prune --unshallow
       - uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476
         with:
-          init-shell: ${{ matrix.os == 'windows-latest' && 'cmd.exe' || 'bash' }}
+          init-shell: ${{ matrix.os == 'windows-2022' && 'cmd.exe' || 'bash' }}
           micromamba-version: 1.5.10-0
           environment-name: build
           create-args: conda-build
@@ -49,14 +49,14 @@ jobs:
             - "${CONDA_BUILD_SYSROOT}"
           EOF
       - name: Build conda package (unix)
-        if: matrix.os != 'windows-latest'
+        if: matrix.os != 'windows-2022'
         shell: bash -el {0}
         run: >-
           conda-build
           -m ".ci_support/${{ matrix.CONDA_BUILD_YML }}.yaml"${{ matrix.conda-build-args }}
           conda.recipe
       - name: Build conda package (windows)
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2022'
         shell: cmd /C CALL {0}
         run: >-
           conda-build


### PR DESCRIPTION
<!-- ⚠️ This is an open-source repository. Do not share sensitive information. -->

Same as https://github.com/Quantco/glum/pull/1009.

Keeping the runners on windows 2022 until we have better support from our build dependencies.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

Checklist
* [ ] Added a `CHANGELOG.rst` entry
